### PR TITLE
T6678: ruff.toml config added to darker lint workflow

### DIFF
--- a/.github/ruff.toml
+++ b/.github/ruff.toml
@@ -1,0 +1,18 @@
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[format]
+quote-style = "single"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/.github/workflows/lint-with-darker-ruff.yml
+++ b/.github/workflows/lint-with-darker-ruff.yml
@@ -11,6 +11,13 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      - name: Checkout reusable actions repo
+        uses: actions/checkout@v3
+        with:
+          repository: vyos/.github
+          path: reusable-actions
+          ref: current
+
       - name: Checkout head
         uses: actions/checkout@v4
         with:
@@ -18,15 +25,24 @@ jobs:
           fetch-tags: true
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: repo
 
       - name: Fetch base
         run: |
+          cd repo
           git fetch https://github.com/${{ github.event.pull_request.base.repo.full_name }} ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/base
 
-      - name: darker install
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Install darker ruff 
         run: |
           pip install git+https://github.com/akaihola/darker.git@master ruff>=0.0.292
 
       - name: Analyze Code
         run: |
+          cd repo
+          cp ../reusable-actions/.github/ruff.toml .
           darker -r origin/base --check --diff --lint "ruff check" --color .


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
T6678: ruff.toml config added to darker lint workflow

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->https://vyos.dev/T6678

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
