### PR TITLE
T6678: ruff fix for changed files

### DIFF
--- a/.github/workflows/lint-with-ruff.yml
+++ b/.github/workflows/lint-with-ruff.yml
@@ -16,17 +16,25 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}  
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Get changed py files
+        id: changed-py-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+             **.py
 
       - name: Ruff Check
+        if: steps.changed-py-files.outputs.any_changed == 'true'
         uses: chartboost/ruff-action@491342200cdd1cf4d5132a30ddc546b3b5bc531b
         with:
           args: check
           changed-files: 'true'
 
       - name: Ruff Format
+        if: always() && steps.changed-py-files.outputs.any_changed == 'true'
         uses: chartboost/ruff-action@491342200cdd1cf4d5132a30ddc546b3b5bc531b
-        if: always()
         with:
           args: format --diff
           changed-files: 'true'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
T6678: ruff fix for changed files
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6678
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
