### PR TITLE
T6674: Actions add bullfrog secure to trigger build packages

### DIFF
--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -2,33 +2,45 @@ name: Workflow to trigger a package build
 
 on:
   workflow_call:
-        inputs:
-            branch:
-                required: true
-                type: string
-                default: current
-            package_name:
-                required: true
-                type: string
-            REF:
-                required: true
-                type: string
-                default: main
-        secrets:
-            REMOTE_OWNER:
-                required: true
-            REMOTE_REUSE_REPO:
-                required: true
-            GPG_KEY_ID:
-                required: true
-            PAT:
-                required: true
+    inputs:
+      branch:
+        description: 'PR target branch'
+        required: true
+        type: string
+        default: current
+      package_name:
+        description: 'PR package name'
+        required: true
+        type: string
+      REF:
+        required: true
+        type: string
+        default: main
+    secrets:
+      REMOTE_OWNER:
+        description: 'Remote repo owner'
+        required: true
+      REMOTE_REUSE_REPO:
+        description: 'Remote reusable repo name'
+        required: true
+      GPG_KEY_ID:
+        description: 'DEB repo GPG key ID'
+        required: true
+      PAT:
+        description: 'Personal Access Token'
+        required: true
 
 jobs:
   trigger_package_build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
+      - name: Bullfrog Secure Runner
+        uses: bullfrogsec/bullfrog@v0
+        with:
+          egress-policy: audit
+
       - name: Trigger rebuild for ${{ inputs.package_name }}
         run: |
           curl -L \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Actions add bullfrog secure runner to trigger build packages action
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
