### PR TITLE
T7426: improved conflict check relaiablity by waiting for github to calculate mergeable state

### DIFF
--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -10,6 +10,36 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Bullfrog Secure Runner
+        uses: bullfrogsec/bullfrog@v0
+        with:
+          egress-policy: audit
+
+      - name: Wait for GitHub to calculate mergeability
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          echo "Waiting for GitHub to compute mergeability for PR #$PR_NUMBER in $REPO..."
+      
+          for i in {1..10}; do
+            sleep 5
+            MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
+            echo "Attempt $i: mergeable = $MERGEABLE"
+      
+            if [[ "$MERGEABLE" != "null" ]]; then
+              echo "Mergeability is now computed: $MERGEABLE"
+              break
+            fi
+      
+            if [[ $i -eq 10 ]]; then
+              echo "Timeout waiting for mergeability to be computed"
+              exit 1
+            fi
+          done
+
       - name: check if PRs are dirty
         uses: eps1lon/actions-label-merge-conflict@v3
         with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vyos/reviewers
+# * @vyos/reviewers


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
T7426: improved conflict check relaiablity by waiting for github to calculate mergeable state

Noticed actions-label-merge-conflict action was removing the "conflicts" label on new push even though branch has conflict.
This is known issue with GitHub as it takes little time to calculate mergeable state of the PR after pushing the new commit.
So added wait in workflow before the conflict check by waiting for Github to calculate mergeable state of the PR.
This should fix this issue.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx --> https://vyos.dev/T7426

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
