### PR TITLE
T7445: added open prs conflict check workflow

### DIFF
--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -1,0 +1,32 @@
+name: "Check Open PRs conflicts"
+
+on:
+  push:
+    branches:
+      - current
+      - sagitta
+      - circinus
+
+jobs:
+  trigger-open-prs-conflict-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (optional, if using local scripts)
+        uses: actions/checkout@v4
+
+      - name: Get PRs targeting ${{ github.ref_name }}
+        id: get-prs
+        run: |
+          prs=$(gh pr list --state open --base "${GITHUB_REF_NAME}" --json number -q '.[].number')
+          echo "PR_NUMBERS=${prs}" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger conflict-checker for each PR
+        run: |
+          for pr in $PR_NUMBERS; do
+            echo "Dispatching conflict-checker for PR #$pr"
+            gh workflow run check-pr-merge-conflict.yml -f pr_number=$pr
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -26,7 +26,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check-pr-conflicts:
-    name: "Check PR #${{ matrix.pr_number }} for conflicts"
     needs: get-open-prs
     strategy:
       matrix:

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -19,7 +19,8 @@ jobs:
         id: get-prs
         run: |
           prs=$(gh pr list --state open --base "${GITHUB_REF_NAME}" --json number -q '.[].number')
-          echo "PR_NUMBERS=${prs}" >> $GITHUB_ENV
+          prs_space_separated=$(echo "$prs" | xargs)
+          echo "PR_NUMBERS=$prs_space_separated" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -2,7 +2,6 @@ name: "Check Open PRs conflicts"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   actions: write      # Required to trigger workflows using gh workflow run

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 permissions:
-  actions: write
   contents: read
+  pull-requests: write
 
 jobs:
   get-open-prs:

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       pr_matrix: ${{ steps.set-matrix.outputs.pr_matrix }}
     steps:
-      - name: Checkout (optional)
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Get PRs targeting ${{ github.ref_name }}

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Trigger conflict-checker for each PR
         run: |
           for pr in $PR_NUMBERS; do
+            # Random sleep to avoid hitting API limits
+            sleep $((RANDOM % 10 + 1))
             echo "Dispatching conflict-checker for PR #$pr"
-            gh workflow run check-pr-merge-conflict.yml -f pr_number=$pr
+            gh workflow run check-pr-conflicts.yml -f pr_number=$pr
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -29,7 +29,7 @@ jobs:
             # Random sleep to avoid hitting API limits
             sleep $((RANDOM % 10 + 1))
             echo "Dispatching conflict-checker for PR #$pr"
-            gh workflow run check-pr-conflicts.yml -f pr_number=$pr
+            gh workflow run check-pr-conflicts-dispatch.yml -f pr_number=$pr
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -4,32 +4,34 @@ on:
   workflow_call:
 
 permissions:
-  actions: write      # Required to trigger workflows using gh workflow run
-  contents: read      # Needed for checking out code (optional but typical)
+  actions: write
+  contents: read
 
 jobs:
-  trigger-open-prs-conflict-checks:
+  get-open-prs:
     runs-on: ubuntu-latest
+    outputs:
+      pr_matrix: ${{ steps.set-matrix.outputs.pr_matrix }}
     steps:
-      - name: Checkout (optional, if using local scripts)
+      - name: Checkout (optional)
         uses: actions/checkout@v4
 
       - name: Get PRs targeting ${{ github.ref_name }}
-        id: get-prs
+        id: set-matrix
         run: |
           prs=$(gh pr list --state open --base "${GITHUB_REF_NAME}" --json number -q '.[].number')
-          prs_space_separated=$(echo "$prs" | xargs)
-          echo "PR_NUMBERS=$prs_space_separated" >> $GITHUB_ENV
+          prs_json=$(echo "$prs" | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({"pr_number": .})')
+          echo "pr_matrix=$prs_json" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Trigger conflict-checker for each PR
-        run: |
-          for pr in $PR_NUMBERS; do
-            # Random sleep to avoid hitting API limits
-            sleep $((RANDOM % 10 + 1))
-            echo "Dispatching conflict-checker for PR #$pr"
-            gh workflow run check-pr-conflicts-dispatch.yml -f pr_number=$pr
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-pr-conflicts:
+    name: "Check PR #${{ matrix.pr_number }} for conflicts"
+    needs: get-open-prs
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-open-prs.outputs.pr_matrix) }}
+    uses: vyos/.github/.github/workflows/check-pr-merge-conflict.yml@T7445-open-prs-conflict-check
+    with:
+      pr_number: ${{ matrix.pr_number }}
+    secrets: inherit

--- a/.github/workflows/check-open-prs-conflict.yml
+++ b/.github/workflows/check-open-prs-conflict.yml
@@ -1,11 +1,12 @@
 name: "Check Open PRs conflicts"
 
 on:
-  push:
-    branches:
-      - current
-      - sagitta
-      - circinus
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  actions: write      # Required to trigger workflows using gh workflow run
+  contents: read      # Needed for checking out code (optional but typical)
 
 jobs:
   trigger-open-prs-conflict-checks:

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -77,7 +77,7 @@ jobs:
 
             if [[ "$HAD_CONFLICT_LABEL" == "true" ]]; then
               echo "💬 Posting 'conflicts resolved' comment..."
-              gh pr comment "$PR_NUMBER" --body "✅ **Conflicts have been resolved.** $COMMENT_ON_RESOLUTION"
+              gh pr comment "$PR_NUMBER" --body "✅ **Conflicts Resolved.** $COMMENT_ON_RESOLUTION"
             fi
           else
             echo "❌ PR has merge conflicts — adding '$CONFLICT_LABEL' label."
@@ -90,5 +90,5 @@ jobs:
             gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
 
             echo "💬 Posting 'has conflicts' comment..."
-            gh pr comment "$PR_NUMBER" --body "❌ **This pull request has conflicts.** $COMMENT_ON_CONFLICT"
+            gh pr comment "$PR_NUMBER" --body "❌ **Conflicts Found.** $COMMENT_ON_CONFLICT"
           fi

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -15,36 +15,67 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Wait for GitHub to calculate mergeability
-        shell: bash
+      - name: Checkout PR and base branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full history for merge operations
+
+      - name: Fetch base and head branches
+        run: |
+          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
+
+      - name: Attempt merge using Git (show output)
+        id: merge_check
+        run: |
+          echo "Checking merge of '${{ github.head_ref }}' into '${{ github.base_ref }}'..."
+          git checkout -B merge-base origin/${{ github.base_ref }}
+          if git merge --no-commit --no-ff origin/${{ github.head_ref }}; then
+            echo "mergeable=true" >> $GITHUB_OUTPUT
+            git merge --abort
+          else
+            echo "mergeable=false" >> $GITHUB_OUTPUT
+            git merge --abort
+          fi
+
+      - name: Check if 'conflict' label exists
+        id: label_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          REPO=${{ github.repository }}
-          echo "Waiting for GitHub to compute mergeability for PR #$PR_NUMBER in $REPO..."
-      
-          for i in {1..10}; do
-            sleep 5
-            MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
-            echo "Attempt $i: mergeable = $MERGEABLE"
-      
-            if [[ "$MERGEABLE" != "null" ]]; then
-              echo "Mergeability is now computed: $MERGEABLE"
-              break
-            fi
-      
-            if [[ $i -eq 10 ]]; then
-              echo "Timeout waiting for mergeability to be computed"
-              exit 1
-            fi
-          done
+          LABEL="conflict"
+          echo "🔍 Checking if PR #$PR_NUMBER has the '$LABEL' label using jq..."
+          LABEL_EXISTS=$(gh pr view "$PR_NUMBER" --json labels | jq -r --arg label "$LABEL" '.labels[].name | select(. == $label)' | wc -l)
 
-      - name: check if PRs are dirty
-        uses: eps1lon/actions-label-merge-conflict@v3
-        with:
-          dirtyLabel: "conflicts"
-          removeOnDirtyLabel: "state: conflict resolved"
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
-          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."
+          if [[ "$LABEL_EXISTS" -gt 0 ]]; then
+            echo "has_conflict_label=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflict_label=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add or remove conflict label based on mergeability
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          MERGEABLE="${{ steps.merge_check.outputs.mergeable }}"
+          HAD_CONFLICT_LABEL="${{ steps.label_check.outputs.has_conflict_label }}"
+          LABEL="conflict"
+          REMOVE_LABEL_ON_CONFLICT="state: conflict resolved"
+
+          if [[ "$MERGEABLE" == "true" ]]; then
+            echo "✅ PR is mergeable — removing '$LABEL' label if it exists."
+            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" || true
+
+            if [[ "$HAD_CONFLICT_LABEL" == "true" ]]; then
+              echo "💬 Posting 'conflicts resolved' comment..."
+              gh pr comment "$PR_NUMBER" --body "✅ **Conflicts have been resolved.** A maintainer will review the pull request shortly."
+            fi
+          else
+            echo "❌ PR has merge conflicts — adding '$LABEL' label."
+            gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+            gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
+
+            echo "💬 Posting 'has conflicts' comment..."
+            gh pr comment "$PR_NUMBER" --body "❌ **This pull request has conflicts.** Please resolve them before we can evaluate the pull request."
+          fi

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -99,14 +99,19 @@ jobs:
               gh pr comment "$PR_NUMBER" --body "✅ **Conflicts Resolved.** $COMMENT_ON_RESOLUTION"
             fi
           else
-            echo "❌ PR has merge conflicts — adding '$CONFLICT_LABEL' label."
-            if ! gh label list --json name | jq -e --arg label "$CONFLICT_LABEL" '.[] | select(.name == $label)' > /dev/null; then
-              gh label create "$CONFLICT_LABEL" --color "d73a4a" --description "PR has merge conflicts"
+            echo "❌ PR has merge conflicts."
+            if [[ "$HAD_CONFLICT_LABEL" == "true" ]]; then
+              echo "ℹ️ Conflict label already exists — no update needed."
+            else
+              echo "➕ Adding '$CONFLICT_LABEL' label."
+              if ! gh label list --json name | jq -e --arg label "$CONFLICT_LABEL" '.[] | select(.name == $label)' > /dev/null; then
+                gh label create "$CONFLICT_LABEL" --color "d73a4a" --description "PR has merge conflicts"
+              fi
+              gh pr edit "$PR_NUMBER" --add-label "$CONFLICT_LABEL"
+              echo "💬 Posting 'has conflicts' comment..."
+              gh pr comment "$PR_NUMBER" --body "❌ **Conflicts Found.** $COMMENT_ON_CONFLICT"
             fi
-            gh pr edit "$PR_NUMBER" --add-label "$CONFLICT_LABEL"
             gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
-            echo "💬 Posting 'has conflicts' comment..."
-            gh pr comment "$PR_NUMBER" --body "❌ **Conflicts Found.** $COMMENT_ON_CONFLICT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -15,17 +15,22 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout PR and base branch
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full history for merge operations
 
-      - name: Fetch base and head branches
+      - name: Set Git user identity
         run: |
-          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
 
-      - name: Attempt merge using Git (show output)
-        id: merge_check
+      - name: Fetch base and PR branches
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git fetch origin ${{ github.head_ref }}
+
+      - name: Check for merge conflicts
         run: |
           echo "Checking merge of '${{ github.head_ref }}' into '${{ github.base_ref }}'..."
           git checkout -B merge-base origin/${{ github.base_ref }}

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -81,6 +81,11 @@ jobs:
             fi
           else
             echo "❌ PR has merge conflicts — adding '$CONFLICT_LABEL' label."
+            if ! gh label list --json name | jq -e --arg label "$LABEL" '.[] | select(.name == $label)' > /dev/null; then
+              COLOR="d73a4a"  # red
+              DESCRIPTION="PR has merge conflicts"
+              gh label create "$CONFLICT_LABEL" --color "$COLOR" --description "$DESCRIPTION"
+            fi
             gh pr edit "$PR_NUMBER" --add-label "$CONFLICT_LABEL"
             gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
 

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -6,7 +6,7 @@ on:
       pr_number:
         description: "Pull Request Number"
         required: true
-        type: number
+        type: string
 
 jobs:
   pr-conflict-check:
@@ -35,7 +35,7 @@ jobs:
         id: pr_info
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            PR_NUMBER=${{ inputs.pr_number }}
+            PR_NUMBER="${{ inputs.pr_number }}"
             echo "Triggered manually for PR #$PR_NUMBER"
             pr_json=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName --jq '{base: .baseRefName, head: .headRefName}')
             BASE=$(echo $pr_json | jq -r .base)

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -41,6 +41,7 @@ jobs:
             BASE=$(echo $pr_json | jq -r .base)
             HEAD=$(echo $pr_json | jq -r .head)
           else
+            echo "Triggered via pull_request event"
             PR_NUMBER=${{ github.event.pull_request.number }}
             BASE=${{ github.event.pull_request.base.ref }}
             HEAD=${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -1,9 +1,15 @@
 name: "Check PR merge conflicts"
 on:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull Request Number"
+        required: true
+        type: number
 
 jobs:
-  pr-conflict-Check:
+  pr-conflict-check:
     name: 'Check PR status: conflicts and resolution'
     runs-on: ubuntu-latest
     permissions:
@@ -23,24 +29,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Ensure full history for merge operations
+          fetch-depth: 0
+
+      - name: Determine PR number and branches
+        id: pr_info
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PR_NUMBER=${{ inputs.pr_number }}
+            echo "Triggered manually for PR #$PR_NUMBER"
+            pr_json=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName --jq '{base: .baseRefName, head: .headRefName}')
+            BASE=$(echo $pr_json | jq -r .base)
+            HEAD=$(echo $pr_json | jq -r .head)
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            BASE=${{ github.event.pull_request.base.ref }}
+            HEAD=${{ github.event.pull_request.head.ref }}
+            echo "Triggered by PR event for PR #$PR_NUMBER"
+          fi
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "base_branch=$BASE" >> $GITHUB_OUTPUT
+          echo "head_branch=$HEAD" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Git user identity
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Fetch base and PR branches
+      - name: Fetch base and head branches
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}
+          git fetch origin ${{ steps.pr_info.outputs.base_branch }}
+          git fetch origin ${{ steps.pr_info.outputs.head_branch }}
 
       - name: Check for merge conflicts
         id: merge_check
         run: |
-          echo "Checking merge of '${{ github.head_ref }}' into '${{ github.base_ref }}'..."
-          git checkout -B merge-base origin/${{ github.base_ref }}
-          if git merge --no-commit --no-ff origin/${{ github.head_ref }}; then
+          echo "Checking merge of '${{ steps.pr_info.outputs.head_branch }}' into '${{ steps.pr_info.outputs.base_branch }}'..."
+          git checkout -B merge-base origin/${{ steps.pr_info.outputs.base_branch }}
+          if git merge --no-commit --no-ff origin/${{ steps.pr_info.outputs.head_branch }}; then
             echo "mergeable=true" >> $GITHUB_OUTPUT
             git merge --abort
           else
@@ -48,29 +75,21 @@ jobs:
             git merge --abort
           fi
 
-      - name: Check if 'conflict' label exists
+      - name: Check if conflict label exists
         id: conflict_label_check
+        run: |
+          PR_NUMBER=${{ steps.pr_info.outputs.pr_number }}
+          LABEL_EXISTS=$(gh pr view "$PR_NUMBER" --json labels | jq -r --arg label "${{ env.CONFLICT_LABEL }}" '.labels[].name | select(. == $label)' | wc -l)
+          [[ "$LABEL_EXISTS" -gt 0 ]] && echo "has_conflict_label=true" >> $GITHUB_OUTPUT || echo "has_conflict_label=false" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          echo "🔍 Checking if PR #$PR_NUMBER has the '$CONFLICT_LABEL' label using jq..."
-          LABEL_EXISTS=$(gh pr view "$PR_NUMBER" --json labels | jq -r --arg label "$CONFLICT_LABEL" '.labels[].name | select(. == $label)' | wc -l)
-
-          if [[ "$LABEL_EXISTS" -gt 0 ]]; then
-            echo "has_conflict_label=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_conflict_label=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Add or remove conflict label based on mergeability
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_NUMBER=${{ steps.pr_info.outputs.pr_number }}
           MERGEABLE="${{ steps.merge_check.outputs.mergeable }}"
           HAD_CONFLICT_LABEL="${{ steps.conflict_label_check.outputs.has_conflict_label }}"
-          
+
           if [[ "$MERGEABLE" == "true" ]]; then
             echo "✅ PR is mergeable — removing '$CONFLICT_LABEL' label if it exists."
             gh pr edit "$PR_NUMBER" --remove-label "$CONFLICT_LABEL" || true
@@ -81,14 +100,13 @@ jobs:
             fi
           else
             echo "❌ PR has merge conflicts — adding '$CONFLICT_LABEL' label."
-            if ! gh label list --json name | jq -e --arg label "$LABEL" '.[] | select(.name == $label)' > /dev/null; then
-              COLOR="d73a4a"  # red
-              DESCRIPTION="PR has merge conflicts"
-              gh label create "$CONFLICT_LABEL" --color "$COLOR" --description "$DESCRIPTION"
+            if ! gh label list --json name | jq -e --arg label "$CONFLICT_LABEL" '.[] | select(.name == $label)' > /dev/null; then
+              gh label create "$CONFLICT_LABEL" --color "d73a4a" --description "PR has merge conflicts"
             fi
             gh pr edit "$PR_NUMBER" --add-label "$CONFLICT_LABEL"
             gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
-
             echo "💬 Posting 'has conflicts' comment..."
             gh pr comment "$PR_NUMBER" --body "❌ **Conflicts Found.** $COMMENT_ON_CONFLICT"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pr-conflict-check:
-    name: 'Check PR status: conflicts and resolution'
+    name: "Check PR #${{ inputs.pr_number != '' && inputs.pr_number || github.event.pull_request.number }}"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,19 +33,19 @@ jobs:
       - name: Determine PR number and branches
         id: pr_info
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ -n "${{ inputs.pr_number }}" ]]; then
             PR_NUMBER="${{ inputs.pr_number }}"
-            echo "Triggered manually for PR #$PR_NUMBER"
+            echo "PR number provided as input: #$PR_NUMBER"
             pr_json=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName --jq '{base: .baseRefName, head: .headRefName}')
-            BASE=$(echo $pr_json | jq -r .base)
-            HEAD=$(echo $pr_json | jq -r .head)
+            BASE=$(echo "$pr_json" | jq -r .base)
+            HEAD=$(echo "$pr_json" | jq -r .head)
           else
-            echo "Triggered via pull_request event"
-            PR_NUMBER=${{ github.event.pull_request.number }}
-            BASE=${{ github.event.pull_request.base.ref }}
-            HEAD=${{ github.event.pull_request.head.ref }}
-            echo "Triggered by PR event for PR #$PR_NUMBER"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            BASE="${{ github.event.pull_request.base.ref }}"
+            HEAD="${{ github.event.pull_request.head.ref }}"
+            echo "PR number from event: #$PR_NUMBER"
           fi
+
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "base_branch=$BASE" >> $GITHUB_OUTPUT
           echo "head_branch=$HEAD" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -9,6 +9,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      CONFLICT_LABEL: "conflicts"
+      REMOVE_LABEL_ON_CONFLICT: "state: conflict resolved"
+      COMMENT_ON_CONFLICT: "This pull request has conflicts. Please resolve them before we can evaluate the pull request."
+      COMMENT_ON_RESOLUTION: "Conflicts have been resolved. A maintainer will review the pull request shortly."
     steps:
       - name: Bullfrog Secure Runner
         uses: bullfrogsec/bullfrog@v0
@@ -31,6 +36,7 @@ jobs:
           git fetch origin ${{ github.head_ref }}
 
       - name: Check for merge conflicts
+        id: merge_check
         run: |
           echo "Checking merge of '${{ github.head_ref }}' into '${{ github.base_ref }}'..."
           git checkout -B merge-base origin/${{ github.base_ref }}
@@ -43,14 +49,13 @@ jobs:
           fi
 
       - name: Check if 'conflict' label exists
-        id: label_check
+        id: conflict_label_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          LABEL="conflict"
-          echo "🔍 Checking if PR #$PR_NUMBER has the '$LABEL' label using jq..."
-          LABEL_EXISTS=$(gh pr view "$PR_NUMBER" --json labels | jq -r --arg label "$LABEL" '.labels[].name | select(. == $label)' | wc -l)
+          echo "🔍 Checking if PR #$PR_NUMBER has the '$CONFLICT_LABEL' label using jq..."
+          LABEL_EXISTS=$(gh pr view "$PR_NUMBER" --json labels | jq -r --arg label "$CONFLICT_LABEL" '.labels[].name | select(. == $label)' | wc -l)
 
           if [[ "$LABEL_EXISTS" -gt 0 ]]; then
             echo "has_conflict_label=true" >> "$GITHUB_OUTPUT"
@@ -64,23 +69,21 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           MERGEABLE="${{ steps.merge_check.outputs.mergeable }}"
-          HAD_CONFLICT_LABEL="${{ steps.label_check.outputs.has_conflict_label }}"
-          LABEL="conflict"
-          REMOVE_LABEL_ON_CONFLICT="state: conflict resolved"
-
+          HAD_CONFLICT_LABEL="${{ steps.conflict_label_check.outputs.has_conflict_label }}"
+          
           if [[ "$MERGEABLE" == "true" ]]; then
-            echo "✅ PR is mergeable — removing '$LABEL' label if it exists."
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" || true
+            echo "✅ PR is mergeable — removing '$CONFLICT_LABEL' label if it exists."
+            gh pr edit "$PR_NUMBER" --remove-label "$CONFLICT_LABEL" || true
 
             if [[ "$HAD_CONFLICT_LABEL" == "true" ]]; then
               echo "💬 Posting 'conflicts resolved' comment..."
-              gh pr comment "$PR_NUMBER" --body "✅ **Conflicts have been resolved.** A maintainer will review the pull request shortly."
+              gh pr comment "$PR_NUMBER" --body "✅ **Conflicts have been resolved.** $COMMENT_ON_RESOLUTION"
             fi
           else
-            echo "❌ PR has merge conflicts — adding '$LABEL' label."
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+            echo "❌ PR has merge conflicts — adding '$CONFLICT_LABEL' label."
+            gh pr edit "$PR_NUMBER" --add-label "$CONFLICT_LABEL"
             gh pr edit "$PR_NUMBER" --remove-label "$REMOVE_LABEL_ON_CONFLICT" || true
 
             echo "💬 Posting 'has conflicts' comment..."
-            gh pr comment "$PR_NUMBER" --body "❌ **This pull request has conflicts.** Please resolve them before we can evaluate the pull request."
+            gh pr comment "$PR_NUMBER" --body "❌ **This pull request has conflicts.** $COMMENT_ON_CONFLICT"
           fi

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -1,11 +1,10 @@
 name: "Check PR merge conflicts"
 on:
   workflow_call:
-  workflow_dispatch:
     inputs:
       pr_number:
         description: "Pull Request Number"
-        required: true
+        required: false
         type: number
 
 jobs:

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -20,6 +20,13 @@ jobs:
       COMMENT_ON_CONFLICT: "This pull request has conflicts. Please resolve them before we can evaluate the pull request."
       COMMENT_ON_RESOLUTION: "Conflicts have been resolved. A maintainer will review the pull request shortly."
     steps:
+      - name: Optional delay when triggered with pr_number
+        if: inputs.pr_number != ''
+        run: |
+          delay=$(( ( RANDOM % 10 ) + 5 ))
+          echo "Running in matrix mode. Sleeping for $delay seconds..."
+          sleep $delay
+
       - name: Bullfrog Secure Runner
         uses: bullfrogsec/bullfrog@v0
         with:

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -6,7 +6,7 @@ on:
       pr_number:
         description: "Pull Request Number"
         required: true
-        type: string
+        type: number
 
 jobs:
   pr-conflict-check:
@@ -35,7 +35,7 @@ jobs:
         id: pr_info
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
+            PR_NUMBER=${{ inputs.pr_number }}
             echo "Triggered manually for PR #$PR_NUMBER"
             pr_json=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName --jq '{base: .baseRefName, head: .headRefName}')
             BASE=$(echo $pr_json | jq -r .base)

--- a/.github/workflows/check-pr-merge-conflict.yml
+++ b/.github/workflows/check-pr-merge-conflict.yml
@@ -5,7 +5,7 @@ on:
       pr_number:
         description: "Pull Request Number"
         required: false
-        type: number
+        type: string
 
 jobs:
   pr-conflict-check:
@@ -34,7 +34,7 @@ jobs:
         id: pr_info
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            PR_NUMBER=${{ inputs.pr_number }}
+            PR_NUMBER="${{ inputs.pr_number }}"
             echo "Triggered manually for PR #$PR_NUMBER"
             pr_json=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName --jq '{base: .baseRefName, head: .headRefName}')
             BASE=$(echo $pr_json | jq -r .base)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->



## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The conflict check workflow that we have will run only when the head branch of PR is pushed/updated.
This workflow will not run when the base branch of the PR is updated/pushed outside this PR may have potential conflicts. So the PR will not get the conflicts label when the base branch is updated by other  (other PR) pushes that create conflict.

To address this, added this workflow (open-prs-conflict-checker) with on push trigger on long-living branches (current, sagitta, circinus), whenever push happens in any one of these branches, will trigger this workflow, will take all the open PRs of the triggered branch, trigger/run the conflict-checker workflow on that PRs which can get the conflict label to that PR if it has conflicts.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx --> https://vyos.dev/T7445

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
