### PR TITLE
T7748: conflict check workflow updated to use marketplace action with increased wait/retry

### DIFF
--- a/.github/workflows/check-pr-conflict.yml
+++ b/.github/workflows/check-pr-conflict.yml
@@ -1,0 +1,28 @@
+name: "Check PRs conflict"
+on:
+  workflow_call:
+
+jobs:
+  prs-conflict-Check:
+    name: 'Check PRs status: conflicts and resolution'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Bullfrog Secure Runner
+        continue-on-error: true
+        uses: bullfrogsec/bullfrog@v0.8.4
+        with:
+          egress-policy: audit
+
+      - name: check if PRs are dirty
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "conflicts"
+          removeOnDirtyLabel: "state: conflict resolved"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          retryAfter: 120
+          retryMax: 10
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Conflict check workflow updated to use marketplace action along with increased wait and retry

**Background**:
As per [prince-chrismc/label-merge-conflicts-action: GitHub Action to automatically label PRs with merge conflicts](https://github.com/prince-chrismc/label-merge-conflicts-action)

```text
Limitations:
GitHub does not reliably compute the mergeable status which is used by this action to detect merge conflicts. If the base branch (e.g. main) changes then the mergeable status is unknown until someone (like this action) requests it. [GitHub then tries to compute the status with an async job.](https://stackoverflow.com/a/30620973). This is usually quick and simple, but there are no guarantees and GitHub might have issues. You can tweak max_retries and wait_ms to increase the timeout before giving up on the Pull Request.

GitHub does not run actions on pull requests which have conflicts - which will prevent this action from working. When there is a conflict it prevents the merge commit from being calculated. [See this thread](https://github.community/t/run-actions-on-pull-requests-with-merge-conflicts/17104) for more details. This is required for the mergeable as per the [API documentation](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request)_
```

This is the known issue with GitHub for checking the conflict. same when using git cli as well.
So, prefer to use the out-of-box action here instead of custom code with increased wait and retry

Switching to eps1lon/actions-label-merge-conflict ([eps1lon/actions-label-merge-conflict: GitHub action that adds a label once a PR has merge conflicts](https://github.com/eps1lon/actions-label-merge-conflict)) with retry wait and max retries .

Using the below settings for reliable detection even in worst-case GitHub delays.
```text
retryAfter: 120
retryMax: 10
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7748

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
