### PR TITLE
T7877: Preserved leading whitespace in mirrored PR bodies

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -235,7 +235,7 @@ jobs:
           last_commit=$(echo $pr_info | jq -r '.headRefOid')
           echo "Last commit retrived from pr view ${last_commit}"
           merge_commit=$(echo $pr_info | jq -r '.mergeCommit.oid')
-          pr_body=$(echo $pr_info | jq -r '.body')
+          pr_body=$(echo "$pr_info" | jq -j '.body')   # preserve indentation
           pr_title=$(echo $pr_info | jq -r '.title')
           echo "pr_title=${pr_title}" >> $GITHUB_ENV
           pr_labels=$(echo $pr_info | jq -r '.labels | map(.name) | join(",")')
@@ -264,8 +264,7 @@ jobs:
           {
             echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
             echo ""
-            # Preserve whitespace exactly
-            cat <<<"$pr_body"
+            printf '%s\n' "$pr_body"   # exact preservation
           } > /tmp/pr_body.txt
           echo "Last commit retrived ${last_commit}, Merge commit retrived ${merge_commit}, PR labels retrived ${pr_labels}"
 

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -259,13 +259,13 @@ jobs:
           fi
           echo "last_commit=${last_commit}" >> $GITHUB_ENV
           echo "merge_commit=${merge_commit}" >> $GITHUB_ENV
-          # Write full PR body to a file for later usage
+          # Write full PR body to a tmp file for later usage
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
             echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
             echo ""
             echo "$pr_body"
-          } > pr_body.txt
+          } > /tmp/pr_body.txt
           echo "Last commit retrived ${last_commit}, Merge commit retrived ${merge_commit}, PR labels retrived ${pr_labels}"
 
       - name: Create mirror PR head branch (temp feature branch)
@@ -285,7 +285,12 @@ jobs:
         if: env.mirror_required == 'true'
         run: |
           title="${pr_title} (mirror ${PR_NUMBER})"
-          pr_url=$(gh pr create --repo ${TARGET_REPO} --head $pr_head_branch --base $SYNC_BRANCH --title "${title}" --body-file pr_body.txt)
+          pr_url=$(gh pr create \
+            --repo ${TARGET_REPO} \
+            --head $pr_head_branch \
+            --base $SYNC_BRANCH \
+            --title "${title}" \
+            --body-file /tmp/pr_body.txt)
           echo "Created PR url retrived ${pr_url}"
           pr_number=$(basename $pr_url)
           echo "mirror_pr_number=${pr_number}" >> $GITHUB_ENV

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -236,9 +236,9 @@ jobs:
           echo "Last commit retrived from pr view ${last_commit}"
           merge_commit=$(echo $pr_info | jq -r '.mergeCommit.oid')
           pr_body=$(echo $pr_info | jq -r '.body')
-          echo "pr_body<<EOF" >> $GITHUB_ENV
-          echo "$pr_body" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          # echo "pr_body<<EOF" >> $GITHUB_ENV
+          # echo "$pr_body" >> $GITHUB_ENV
+          # echo "EOF" >> $GITHUB_ENV
           pr_title=$(echo $pr_info | jq -r '.title')
           echo "pr_title=${pr_title}" >> $GITHUB_ENV
           pr_labels=$(echo $pr_info | jq -r '.labels | map(.name) | join(",")')
@@ -262,6 +262,13 @@ jobs:
           fi
           echo "last_commit=${last_commit}" >> $GITHUB_ENV
           echo "merge_commit=${merge_commit}" >> $GITHUB_ENV
+          # Write full PR body to a file for later
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
+            echo ""
+            echo "$pr_body"
+          } > pr_body.txt
           echo "Last commit retrived ${last_commit}, Merge commit retrived ${merge_commit}, PR labels retrived ${pr_labels}"
 
       - name: Create mirror PR head branch (temp feature branch)
@@ -282,10 +289,11 @@ jobs:
         run: |
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           title="${pr_title} (mirror ${PR_NUMBER})"
-          echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})." > pr_body.txt
-          echo "" >> pr_body.txt
-          echo "${pr_body}" >> pr_body.txt
-          pr_url=$(gh pr create --repo ${TARGET_REPO} --head $pr_head_branch --base $SYNC_BRANCH --title "${title}" --body "$(cat pr_body.txt)")
+          # echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})." > pr_body.txt
+          # echo "" >> pr_body.txt
+          # echo "${pr_body}" >> pr_body.txt
+          pr_url=$(gh pr create --repo ${TARGET_REPO} --head $pr_head_branch --base $SYNC_BRANCH --title "${title}" --body-file pr_body.txt)
+          # --body "$(cat pr_body.txt)")
           echo "Created PR url retrived ${pr_url}"
           pr_number=$(basename $pr_url)
           echo "mirror_pr_number=${pr_number}" >> $GITHUB_ENV

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -264,7 +264,8 @@ jobs:
           {
             echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
             echo ""
-            echo "$pr_body"
+            # Preserve whitespace exactly
+            cat <<<"$pr_body"
           } > /tmp/pr_body.txt
           echo "Last commit retrived ${last_commit}, Merge commit retrived ${merge_commit}, PR labels retrived ${pr_labels}"
 

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -236,9 +236,6 @@ jobs:
           echo "Last commit retrived from pr view ${last_commit}"
           merge_commit=$(echo $pr_info | jq -r '.mergeCommit.oid')
           pr_body=$(echo $pr_info | jq -r '.body')
-          # echo "pr_body<<EOF" >> $GITHUB_ENV
-          # echo "$pr_body" >> $GITHUB_ENV
-          # echo "EOF" >> $GITHUB_ENV
           pr_title=$(echo $pr_info | jq -r '.title')
           echo "pr_title=${pr_title}" >> $GITHUB_ENV
           pr_labels=$(echo $pr_info | jq -r '.labels | map(.name) | join(",")')
@@ -262,7 +259,7 @@ jobs:
           fi
           echo "last_commit=${last_commit}" >> $GITHUB_ENV
           echo "merge_commit=${merge_commit}" >> $GITHUB_ENV
-          # Write full PR body to a file for later
+          # Write full PR body to a file for later usage
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
             echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
@@ -287,13 +284,8 @@ jobs:
       - name: Create mirror PR
         if: env.mirror_required == 'true'
         run: |
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           title="${pr_title} (mirror ${PR_NUMBER})"
-          # echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})." > pr_body.txt
-          # echo "" >> pr_body.txt
-          # echo "${pr_body}" >> pr_body.txt
           pr_url=$(gh pr create --repo ${TARGET_REPO} --head $pr_head_branch --base $SYNC_BRANCH --title "${title}" --body-file pr_body.txt)
-          # --body "$(cat pr_body.txt)")
           echo "Created PR url retrived ${pr_url}"
           pr_number=$(basename $pr_url)
           echo "mirror_pr_number=${pr_number}" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
### Description

Fixed an issue where leading whitespaces inside code blocks (e.g., ```diff) were being stripped when mirroring PRs.  
This was caused by using `jq -r` to extract the PR body, which trimmed leading spaces and broke code block formatting.  

The implementation now uses:

```bash
jq -j '.body'
```
instead of jq -r '.body', ensuring that indentation and leading whitespace are preserved.
Additionally, printf is used when writing the body to file, to avoid echo-related trimming.

validated with sample https://github.com/VyOS-Networks/gh-action-test-vyos-1x/pull/178


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx --> https://vyos.dev/T7877

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
