### PR TITLE
T8487: Fix typos and errors for github repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ the box, please use [x]
 <!---
 Please describe in detail how you tested your changes. Include details of your testing
 environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
-and other large chunks of text, surround this text with triple backtics
+and other large chunks of text, surround this text with triple backticks
 ```
 like this
 ```

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -215,7 +215,7 @@ jobs:
           if [[ -z "$previous_merged_source_pr" ]]; then
             echo "No previous merged PR found for branch ${SYNC_BRANCH}"
           else 
-            echo "Previous merged source PR retrived ${previous_merged_source_pr}"
+            echo "Previous merged source PR retrieved ${previous_merged_source_pr}"
             pr_labels=$(gh pr view $previous_merged_source_pr --repo ${SOURCE_REPO} --json labels --jq '.labels | map(.name)')
             if [[ $pr_labels == *"${MIRROR_COMPLETED_LABEL}"* ]]; then
               echo "Found previous merged PR (#${previous_merged_source_pr}) mirrored"
@@ -231,9 +231,9 @@ jobs:
         run: |
           cd $checkout_folder
           pr_info=$(gh pr view $PR_NUMBER --repo $SOURCE_REPO --json commits,mergeCommit,body,title,labels,headRefOid)
-          echo "PR info retrived ${pr_info}"
+          echo "PR info retrieved ${pr_info}"
           last_commit=$(echo $pr_info | jq -r '.headRefOid')
-          echo "Last commit retrived from pr view ${last_commit}"
+          echo "Last commit retrieved from pr view ${last_commit}"
           merge_commit=$(echo $pr_info | jq -r '.mergeCommit.oid')
           pr_body=$(echo "$pr_info" | jq -j '.body')   # preserve indentation
           pr_title=$(echo $pr_info | jq -r '.title')
@@ -266,7 +266,7 @@ jobs:
             echo ""
             printf '%s\n' "$pr_body"   # exact preservation
           } > /tmp/pr_body.txt
-          echo "Last commit retrived ${last_commit}, Merge commit retrived ${merge_commit}, PR labels retrived ${pr_labels}"
+          echo "Last commit retrieved ${last_commit}, Merge commit retrieved ${merge_commit}, PR labels retrieved ${pr_labels}"
 
       - name: Create mirror PR head branch (temp feature branch)
         if: env.mirror_required == 'true'
@@ -291,7 +291,7 @@ jobs:
             --base $SYNC_BRANCH \
             --title "${title}" \
             --body-file /tmp/pr_body.txt)
-          echo "Created PR url retrived ${pr_url}"
+          echo "Created PR url retrieved ${pr_url}"
           pr_number=$(basename $pr_url)
           echo "mirror_pr_number=${pr_number}" >> $GITHUB_ENV
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Cosmetic fixes, no functional changes
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8487

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
