### PR TITLE
T8551: use github.token instead of secrets.PAT in check-pr-message

### DIFF
--- a/.github/workflows/check-pr-message.yml
+++ b/.github/workflows/check-pr-message.yml
@@ -4,9 +4,6 @@
   on:
     workflow_call:
 
-  env:
-    GH_TOKEN: ${{ github.token }}
-  
   jobs:
     check-pr-title:
       name: Check pull request title
@@ -17,15 +14,17 @@
       steps:
         - uses: actions/checkout@v3
           timeout-minutes: 2
-    
+
         - name: Checkout reusable actions repo
           uses: actions/checkout@v3
           with:
             repository: vyos/.github
             path: reusable-actions
-  
+
         - name: Check the PR title
           timeout-minutes: 2
+          env:
+            GH_TOKEN: ${{ github.token }}
           run: |
             source_pr_title=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json title -q .title)
             if echo "$source_pr_title" | grep -Pq '^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'; then
@@ -40,6 +39,8 @@
         
         - name: Check commit messages
           timeout-minutes: 2
+          env:
+            GH_TOKEN: ${{ github.token }}
           run: |
             # Fetch commit messages
             commits=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json commits -q '.commits[].messageHeadline')

--- a/.github/workflows/check-pr-message.yml
+++ b/.github/workflows/check-pr-message.yml
@@ -5,7 +5,7 @@
     workflow_call:
 
   env:
-    GH_TOKEN: ${{ secrets.PAT }}
+    GH_TOKEN: ${{ github.token }}
   
   jobs:
     check-pr-title:


### PR DESCRIPTION
## Summary

- `check-pr-message.yml` uses `secrets.PAT` for `GH_TOKEN`, which is unavailable in caller repos (reusable `workflow_call` workflow). The `gh` CLI fails with exit code 4 before any title/commit validation runs.
- Replace with `github.token`, which is always available via the caller's implicit `GITHUB_TOKEN`.

## Observed

https://github.com/vyos/gh-action-test-vyos-build/pull/14 — valid title rejected because `gh pr view` had no auth token.

## Test plan

- [ ] Re-run the check on https://github.com/vyos/gh-action-test-vyos-build/pull/14 after merge — should pass
- [ ] Open a PR with an invalid title on any consumer repo — should correctly reject

https://vyos.dev/T8551