### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+## Project purpose
+
+Org-wide community-health repo for the `vyos` GitHub organisation. Hosts the canonical reusable GitHub Actions workflows (`workflow_call`) consumed by every `vyos/*` repo and many `VyOS-Networks/*` repos, plus PR-validation, doc-linter, typo-checker, and XML preprocessor scripts. Default branch is `current`; changes ship to all consumers immediately — no semver, no release process.
+
+## Tech stack
+
+- GitHub Actions YAML (19 reusable workflows under `.github/workflows/`).
+- Python helpers (`scripts/check-pr-conflicts.py`, `scripts/process-typos.py`, `.github/doc-linter.py`, `scripts/override-default`, `scripts/transclude-template`).
+- Minimal Python deps in `scripts/requirements.txt` (`requests>=2.32.0,<3.0.0`); `lxml` is pulled by consumer repos for the XML preprocessors.
+- Shell helper (`scripts/check-typos.sh`) wrapping the `typos` CLI.
+
+## Build / test / run
+
+No build system, test suite, or lockfile. To exercise a workflow before merging, call it from a consumer repo pinned to a feature branch (`uses: vyos/.github/.github/workflows/<name>.yml@<branch>`). `check-pr-merge-conflict.yml` accepts an `action-ref` input for this.
+
+```
+pip install -r scripts/requirements.txt
+GITHUB_TOKEN=... GITHUB_REPOSITORY=vyos/.github GITHUB_EVENT_NAME=schedule \
+  python scripts/check-pr-conflicts.py
+python .github/doc-linter.py "['path/to/file.rst']"
+python scripts/override-default <xml-dir>
+python scripts/transclude-template <file.xml>
+```
+
+## Repository layout
+
+- `.github/workflows/` — reusable workflows: PR labels (`add-pr-labels`, `add-rebase-label`, `label-backport`, `assign-author`, `check-stale`), PR validation (`check-pr-message`, `check-pr-conflict`, `check-pr-merge-conflict`), linting (`lint-doc`, `lint-j2`, `lint-with-ruff`, `lint-with-darker-ruff`, `check-unused-imports`, `check-typos`), security (`codeql-analysis`), CLA (`cla-check`), package rebuilds (`trigger-rebuild-repo-package`, `trigger-and-wait-rebuild-repo-package`), mirror (`pr-mirror-repo-sync`).
+- `.github/doc-linter.py` — RST/TXT linter (RFC 5737/3849 IPs, ≤80-char lines, `.. stop_vyoslinter` toggles).
+- `.github/.typos.toml` — default `typos` config; excludes `smoketest/**`, `mibs/**`.
+- `scripts/` — helpers (Python + shell).
+- `profile/README.md` — rendered as the `vyos` org landing page.
+- `CODEOWNERS`, `CONTRIBUTING.md`, `PRMirrorOnboarding.md`.
+
+## Cross-repo context
+
+This repo is the canonical workflow library for both orgs. Consumers reference workflows as `uses: vyos/.github/.github/workflows/<name>.yml@current` with no version pin. The mirror pipeline (`pr-mirror-repo-sync.yml`) is currently live for `vyos-1x`, `vyos-build`, `vyos-utils`, and `vyos1x-config`. Sibling `VyOS-Networks/.github` (default branch `git-actions`) is drifted; nine workflows on its `git-actions` branch are staged-but-inactive (zero runs). `vyos/vyos-cla-signatures` provides the CLA reusable. `vyos-documentation` consumes `lint-doc.yml` (which runs `.github/doc-linter.py`).
+
+## Conventions
+
+- Commit / PR title format: `component: T12345: description`. Phorge task ID at https://vyos.dev mandatory. Enforced by `check-pr-message.yml` on the PR title and every commit.
+- Branch model: `current` (rolling, default), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS); `add-pr-labels.yml` maps base branch → label.
+- Backports: `@Mergifyio backport <branch>` (built-in Mergify command). The mirror pipeline injects these from `bp/<branch>` source labels.
+- Workflows here must be reusable (`workflow_call`); never add a non-reusable workflow.
+- Most jobs include a `bullfrogsec/bullfrog@v0.8.4` egress-audit step (non-fatal).
+- Bot identity for cross-org mutations: `vyosbot` via org-level `PAT` and `REMOTE_OWNER` secrets.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/.github`. Canonical side is **here** (`vyos/.github`). The twin is drifted; do not assume parity. Cross-org sync design lives at Confluence page 794394642.
+
+## Notes for future contributors
+
+- Any change merged to `current` ships to every consumer immediately. Test from a feature branch first via `uses: ...@<branch>`.
+- Onboarding a repo to the mirror pipeline: see `PRMirrorOnboarding.md`.
+- Architecture & cross-org drift inventory: Confluence 792723546. GHA security hardening spec: 795344927. GHE baseline audit: 795967489.
+- The repo's own existing in-tree `CLAUDE.md` (project-root) is more detailed; treat it as the authoritative working document.
+
+---
+
+This file is mirrored on Confluence: [`vyos/.github`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818184498). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,3 @@ Mirror twin: `VyOS-Networks/.github`. Canonical side is **here** (`vyos/.github`
 - Onboarding a repo to the mirror pipeline: see `PRMirrorOnboarding.md`.
 - Architecture & cross-org drift inventory: Confluence 792723546. GHA security hardening spec: 795344927. GHE baseline audit: 795967489.
 - The repo's own existing in-tree `CLAUDE.md` (project-root) is more detailed; treat it as the authoritative working document.
-
----
-
-This file is mirrored on Confluence: [`vyos/.github`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818184498). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Org-wide community-health repo for the `vyos` GitHub organisation. Hosts the can
 
 ## Tech stack
 
-- GitHub Actions YAML (19 reusable workflows under `.github/workflows/`).
+- GitHub Actions YAML (18 reusable `workflow_call` workflows + 1 regular workflow (`cla-check.yml`) under `.github/workflows/`).
 - Python helpers (`scripts/check-pr-conflicts.py`, `scripts/process-typos.py`, `.github/doc-linter.py`, `scripts/override-default`, `scripts/transclude-template`).
 - Minimal Python deps in `scripts/requirements.txt` (`requests>=2.32.0,<3.0.0`); `lxml` is pulled by consumer repos for the XML preprocessors.
 - Shell helper (`scripts/check-typos.sh`) wrapping the `typos` CLI.
@@ -42,7 +42,7 @@ This repo is the canonical workflow library for both orgs. Consumers reference w
 - Commit / PR title format: `component: T12345: description`. Phorge task ID at https://vyos.dev mandatory. Enforced by `check-pr-message.yml` on the PR title and every commit.
 - Branch model: `current` (rolling, default), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS); `add-pr-labels.yml` maps base branch → label.
 - Backports: `@Mergifyio backport <branch>` (built-in Mergify command). The mirror pipeline injects these from `bp/<branch>` source labels.
-- Workflows here must be reusable (`workflow_call`); never add a non-reusable workflow.
+- Workflows here must be reusable (`workflow_call`); avoid adding non-reusable workflows unless necessary (the only current exception is `cla-check.yml`, which uses `pull_request_target`).
 - Most jobs include a `bullfrogsec/bullfrog@v0.8.4` egress-audit step (non-fatal).
 - Bot identity for cross-org mutations: `vyosbot` via org-level `PAT` and `REMOTE_OWNER` secrets.
 
@@ -55,4 +55,4 @@ Mirror twin: `VyOS-Networks/.github`. Canonical side is **here** (`vyos/.github`
 - Any change merged to `current` ships to every consumer immediately. Test from a feature branch first via `uses: ...@<branch>`.
 - Onboarding a repo to the mirror pipeline: see `PRMirrorOnboarding.md`.
 - Architecture & cross-org drift inventory: Confluence 792723546. GHA security hardening spec: 795344927. GHE baseline audit: 795967489.
-- The repo's own existing in-tree `CLAUDE.md` (project-root) is more detailed; treat it as the authoritative working document.
+- This file (`CLAUDE.md`) is the authoritative working document for AI agents and contributors; keep it updated when conventions or layout change.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
