### PR TITLE
T8835: added pr mirror local workflow

### DIFF
--- a/.github/workflows/pr-mirror-local.yml
+++ b/.github/workflows/pr-mirror-local.yml
@@ -1,0 +1,35 @@
+name: PR Mirror and Repo Sync - Local
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [current]
+  workflow_dispatch:
+    inputs:
+      sync_branch:
+        description: 'Branch to mirror'
+        required: true
+        default: 'current'
+        type: choice
+        options:
+          - current
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+jobs:
+  call-pr-mirror-repo-sync:
+    if: |
+      github.repository_owner == 'vyos' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
+      )
+    uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@current
+    with:
+      sync_branch: ${{ github.event.inputs.sync_branch || 'current' }}
+    secrets:
+      PAT: ${{ secrets.PAT }}
+      REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added pr mirror workflow

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->https://vyos.dev/T8835

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
