### PR TITLE
feat(mirror-rollout-1): add get-token.yml reusable workflow

### DIFF
--- a/.github/workflows/get-token-smoke-test.yml
+++ b/.github/workflows/get-token-smoke-test.yml
@@ -25,6 +25,11 @@ jobs:
     needs: mint
     runs-on: ubuntu-latest
     steps:
+      - name: Egress audit
+        continue-on-error: true
+        uses: bullfrogsec/bullfrog@v0.8.4
+        with:
+          egress-policy: audit
       - name: Confirm token was minted
         # Pass workflow context via env vars so the shell sees them as $VAR rather
         # than interpolating directly into the script body — workflow-injection

--- a/.github/workflows/get-token-smoke-test.yml
+++ b/.github/workflows/get-token-smoke-test.yml
@@ -1,0 +1,41 @@
+# Smoke test for get-token.yml — manual dispatch only. Mints a token for the
+# specified org installation and asserts it was issued. Token value is masked.
+name: get-token smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: 'Org to mint for: vyos or VyOS-Networks'
+        required: true
+        type: choice
+        options: [vyos, VyOS-Networks]
+
+permissions:
+  contents: read
+
+jobs:
+  mint:
+    uses: ./.github/workflows/get-token.yml
+    with:
+      owner: ${{ inputs.owner }}
+    secrets: inherit
+
+  verify:
+    needs: mint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm token was minted
+        # Pass workflow context via env vars so the shell sees them as $VAR rather
+        # than interpolating directly into the script body — workflow-injection
+        # hardening per https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+        env:
+          OWNER: ${{ inputs.owner }}
+          TOKEN: ${{ needs.mint.outputs.token }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "Token minted successfully for owner=${OWNER} (value masked)"
+          else
+            echo "::error::Token was empty"
+            exit 1
+          fi

--- a/.github/workflows/get-token.yml
+++ b/.github/workflows/get-token.yml
@@ -44,6 +44,11 @@ jobs:
     outputs:
       token: ${{ steps.app-token.outputs.token }}
     steps:
+      - name: Egress audit
+        continue-on-error: true
+        uses: bullfrogsec/bullfrog@v0.8.4
+        with:
+          egress-policy: audit
       - name: Mint installation token
         id: app-token
         # Pinned to SHA per GitHub Actions security best practice.

--- a/.github/workflows/get-token.yml
+++ b/.github/workflows/get-token.yml
@@ -41,7 +41,7 @@ jobs:
         # Tag at time of pinning: v3.2.0 (released 2026-05-12).
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          client-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}

--- a/.github/workflows/get-token.yml
+++ b/.github/workflows/get-token.yml
@@ -1,9 +1,6 @@
 # get-token.yml — reusable workflow that mints a GitHub App installation token
 # for a specified org installation.
 #
-# Spec: ~/.claude/specs/2026-05-16-mirror-pipeline-redesign-design.md §4.2.2
-# Plan: ~/.claude/plans/2026-05-16-mirror-pipeline-rollout-1-pat-to-app-migration.md Task 4
-#
 # IMPORTANT: skip-token-revoke is set to true so the minted token survives
 # beyond this reusable job's lifetime and can be consumed by downstream jobs
 # via `needs.<mint-job>.outputs.token`. GitHub App installation tokens have a
@@ -41,11 +38,10 @@ jobs:
       - name: Mint installation token
         id: app-token
         # Pinned to SHA per GitHub Actions security best practice.
-        # Tag at time of pinning: v3.2.0 (released 2026-05-12). Recorded in
-        # /tmp/rollout-1/state.txt at plan Task 4 Step 2.
+        # Tag at time of pinning: v3.2.0 (released 2026-05-12).
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}

--- a/.github/workflows/get-token.yml
+++ b/.github/workflows/get-token.yml
@@ -1,0 +1,58 @@
+# get-token.yml — reusable workflow that mints a GitHub App installation token
+# for a specified org installation.
+#
+# Spec: ~/.claude/specs/2026-05-16-mirror-pipeline-redesign-design.md §4.2.2
+# Plan: ~/.claude/plans/2026-05-16-mirror-pipeline-rollout-1-pat-to-app-migration.md Task 4
+#
+# IMPORTANT: skip-token-revoke is set to true so the minted token survives
+# beyond this reusable job's lifetime and can be consumed by downstream jobs
+# via `needs.<mint-job>.outputs.token`. GitHub App installation tokens have a
+# 1-hour TTL regardless; this just disables the action's at-job-end revoke.
+name: Mint App Installation Token
+
+on:
+  workflow_call:
+    inputs:
+      owner:
+        description: 'Org / user that owns the App installation (vyos or VyOS-Networks)'
+        required: true
+        type: string
+      repositories:
+        description: 'Optional comma- or newline-separated list of repos for sub-installation token (default: all in installation)'
+        required: false
+        type: string
+        default: ''
+      permissions:
+        description: 'Optional JSON object of fine-grained permissions for least-privilege scoping'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      token:
+        description: 'Installation token (masked in logs)'
+        value: ${{ jobs.mint.outputs.token }}
+
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Mint installation token
+        id: app-token
+        # Pinned to SHA per GitHub Actions security best practice.
+        # Tag at time of pinning: v3.2.0 (released 2026-05-12). Recorded in
+        # /tmp/rollout-1/state.txt at plan Task 4 Step 2.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ inputs.owner }}
+          repositories: ${{ inputs.repositories }}
+          skip-token-revoke: true
+          # Permission overrides are passed through if provided; empty string means use installation defaults.
+          permission-contents: ${{ fromJSON(inputs.permissions || '{}').contents || '' }}
+          permission-pull-requests: ${{ fromJSON(inputs.permissions || '{}').pull_requests || '' }}
+          permission-issues: ${{ fromJSON(inputs.permissions || '{}').issues || '' }}
+          permission-workflows: ${{ fromJSON(inputs.permissions || '{}').workflows || '' }}
+          permission-metadata: ${{ fromJSON(inputs.permissions || '{}').metadata || '' }}

--- a/.github/workflows/get-token.yml
+++ b/.github/workflows/get-token.yml
@@ -15,12 +15,20 @@ on:
         required: true
         type: string
       repositories:
-        description: 'Optional comma- or newline-separated list of repos for sub-installation token (default: all in installation)'
+        description: >
+          Optional comma- or newline-separated list of repos to scope the token to.
+          Leave empty (default) to grant access to all repositories in the installation.
+          Note: passing an empty string is equivalent to omitting the field.
         required: false
         type: string
         default: ''
       permissions:
-        description: 'Optional JSON object of fine-grained permissions for least-privilege scoping'
+        description: >
+          Optional JSON object of fine-grained permission overrides.
+          Only the following keys are honoured by this workflow:
+          contents, pull_requests, issues, workflows, metadata.
+          Any other keys are silently ignored. Example:
+          {"contents":"read","metadata":"read"}
         required: false
         type: string
         default: ''
@@ -32,6 +40,7 @@ on:
 jobs:
   mint:
     runs-on: ubuntu-latest
+    permissions: {}  # This job uses App credentials only; github.token is not needed.
     outputs:
       token: ${{ steps.app-token.outputs.token }}
     steps:


### PR DESCRIPTION
## Summary

Adds the reusable workflow that mints GitHub App installation tokens. First piece of the PAT → App migration (Rollout 1 of the mirror pipeline redesign).

- **New:** `.github/workflows/get-token.yml` — reusable workflow. Inputs: `owner` (required), optional `repositories`, optional `permissions` JSON. Output: `token` (masked installation token, suitable for cross-job consumption via `needs.<job>.outputs.token`). `skip-token-revoke: true` so the token survives beyond the mint job's lifetime (TTL is still GitHub's 1-hour default).
- **New:** `.github/workflows/get-token-smoke-test.yml` — manual `workflow_dispatch` smoke test (owner choice: `vyos` / `VyOS-Networks`).
- Action pinned to SHA `bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0, released 2026-05-12) per Actions security best practice.
- Smoke-test verify step uses `env:` indirection for workflow-context values per GitHub's workflow-injection hardening guide.

This PR is behavior-neutral on the existing mirror pipeline — it only ADDS files; no existing workflow changes. The reusable starts being consumed by the central mirror workflow in a follow-up PR (plan Task 7) AFTER:
1. The `vyos-bot` GitHub App is created at the enterprise level (plan Task 1).
2. App installed on both `vyos` and `VyOS-Networks` orgs (Task 2).
3. `APP_PRIVATE_KEY` + `APP_ID` provisioned as org secret/variable in both orgs (Task 3).
4. Canary verification passes on `vyos/mirror-canary` (sibling Rollout 1a).

## Spec / Plan / Tracking

- Spec: `~/.claude/specs/2026-05-16-mirror-pipeline-redesign-design.md` §4.2.2
- Plan: `~/.claude/plans/2026-05-16-mirror-pipeline-rollout-1-pat-to-app-migration.md` Task 4
- Sibling plan: `~/.claude/plans/2026-05-17-mirror-pipeline-rollout-1a-canary-pair.md`
- Confluence: [Mirror Pipeline Redesign — Spec v1](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/871825417)

## Test plan

- [ ] Post-merge: run `get-token-smoke-test.yml` via `workflow_dispatch` with `owner: vyos` — expect `conclusion: success` (gated on plan Task 3 completion: APP_PRIVATE_KEY + APP_ID present in vyos org secrets/variables).
- [ ] Same with `owner: VyOS-Networks` — expect `conclusion: success` with a distinct installation token.

🤖 Generated by [robots](https://vyos.io)
