### PR TITLE
fix(mirror-rollout-1): strip ${{ }} expression syntax from composite action description strings

### DIFF
--- a/.github/actions/get-token/action.yml
+++ b/.github/actions/get-token/action.yml
@@ -18,6 +18,13 @@
 # IMPORTANT: the underlying action sets `skip-token-revoke: true` so the token
 # survives beyond this step's lifetime (the GitHub App installation token TTL
 # is 1 hour regardless; this just disables the action's at-step-end revoke).
+#
+# GOTCHA when editing: do NOT include ${{ }} expression syntax inside the
+# `description:` string fields below — even as documentation examples. GHA
+# evaluates expression syntax wherever it appears, including in description
+# strings, and rejects the action manifest with "Unrecognized named-value".
+# Use plain prose ("vars.APP_CLIENT_ID") instead of ${{ vars.APP_CLIENT_ID }}.
+# (Caught at job runtime; static lint does not catch it.)
 
 name: Get GitHub App Installation Token
 description: Mint a GitHub App installation token via actions/create-github-app-token (composite form, single-job pattern).
@@ -27,10 +34,10 @@ inputs:
     description: 'Org / user that owns the App installation (vyos or VyOS-Networks).'
     required: true
   client-id:
-    description: 'GitHub App client ID. Callers in this org pass ${{ vars.APP_CLIENT_ID }}.'
+    description: 'GitHub App client ID. Callers in this org pass vars.APP_CLIENT_ID (do not expand inline; pass the expression at the call site).'
     required: true
   private-key:
-    description: 'GitHub App private key (PEM). Callers in this org pass ${{ secrets.APP_PRIVATE_KEY }}. Composite actions cannot read secrets directly; must be threaded via input.'
+    description: 'GitHub App private key (PEM). Callers in this org pass secrets.APP_PRIVATE_KEY. Composite actions cannot read secrets directly; must be threaded via input.'
     required: true
   repositories:
     description: >
@@ -51,7 +58,7 @@ inputs:
 
 outputs:
   token:
-    description: 'Installation token (masked in logs). Consume via ${{ steps.<id>.outputs.token }} in subsequent steps of the same job.'
+    description: 'Installation token (masked in logs). Consume via steps.<id>.outputs.token in subsequent steps of the same job.'
     value: ${{ steps.app-token.outputs.token }}
 
 runs:


### PR DESCRIPTION
## Summary

3rd-iteration fix for Task 4 of mirror pipeline Rollout 1. Removes invalid `${{ }}` expression syntax from `description:` string fields in the composite action shipped at [vyos/.github#125](https://github.com/vyos/.github/pull/125).

### Why

The composite action merged at [vyos/.github#125](https://github.com/vyos/.github/pull/125) failed both post-merge smoke tests at job runtime:

- Run [26421500619](https://github.com/vyos/.github/actions/runs/26421500619) (`owner=vyos`)
- Run [26421501430](https://github.com/vyos/.github/actions/runs/26421501430) (`owner=VyOS-Networks`)

Both with:
```
##[error]/home/runner/work/.github/.github/./.github/actions/get-token/action.yml (Line: 30, Col: 18): Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.APP_CLIENT_ID
##[error]... (Line: 33, Col: 18): Unrecognized named-value: 'secrets'...
##[error]... (Line: 54, Col: 18): Unrecognized named-value: 'steps'...
##[error]Failed to load /home/runner/work/.github/.github/./.github/actions/get-token/action.yml
```

I had included example syntax like `${{ vars.APP_CLIENT_ID }}` and `${{ secrets.APP_PRIVATE_KEY }}` inside the `description:` fields as documentation hints. **GitHub Actions evaluates `${{ }}` expressions wherever they appear in the action manifest** — including inside string description fields meant as docs. The `vars` / `secrets` / `steps` contexts aren't accessible during action manifest loading, so the parser rejects the file before any step runs.

This is a real GHA gotcha that **none of the five static analyzers caught**: Phase 0 local CodeRabbit, GitHub-side CodeRabbit, Copilot review, Codex adversarial review, actionlint. All treat description content as opaque strings; only the runtime parser evaluates them.

### Fix

Three `description:` strings rewritten to use plain prose instead of expression syntax:

- `${{ vars.APP_CLIENT_ID }}` → `vars.APP_CLIENT_ID`
- `${{ secrets.APP_PRIVATE_KEY }}` → `secrets.APP_PRIVATE_KEY`
- `${{ steps.<id>.outputs.token }}` → `steps.<id>.outputs.token`

Added a `GOTCHA when editing` comment in the action.yml header so future editors don't reintroduce the same pattern.

### Test plan

- [ ] Post-merge: run `get-token-smoke-test.yml` via `workflow_dispatch` with `owner: vyos` — expect `conclusion: success` and `Token minted successfully` in verify step (TOKEN non-empty).
- [ ] Same with `owner: VyOS-Networks` — expect `conclusion: success`.

If smoke tests fail AGAIN on this fix, there's a deeper issue beyond the description-syntax error and rollouts 1a/1b are blocked pending investigation.

## Spec / Plan / Tracking

- Spec: `~/.claude/specs/2026-05-16-mirror-pipeline-redesign-design.md` §4.2.2
- Plan: `~/.claude/plans/2026-05-16-mirror-pipeline-rollout-1-pat-to-app-migration.md` Task 4 (3rd iteration)
- Confluence: [Mirror Pipeline Redesign — Spec v1](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/871825417)
- Predecessor PRs: [vyos/.github#124](https://github.com/vyos/.github/pull/124) (reusable, design-broken) → [vyos/.github#125](https://github.com/vyos/.github/pull/125) (composite, syntax-broken) → this PR (syntax-fixed)

🤖 Generated by [robots](https://vyos.io)
