### PR TITLE
scripts: T8934: skip backport-conflict PRs to stop label oscillation

### DIFF
--- a/scripts/check-pr-conflicts.py
+++ b/scripts/check-pr-conflicts.py
@@ -24,6 +24,16 @@ except ImportError:
 
 # Constants
 DEFAULT_CONFLICT_LABEL = "conflicts"
+# Mergify's `backport` action applies this label when a cherry-pick conflicts
+# and the markers get committed into the destination branch (per the central
+# vyos/mergify config: defaults.actions.backport.label_conflicts). When this
+# label is present, the PR is already flagged as needing human resolution and
+# is held back from merge by Mergify's merge_protections. Adding `conflicts`
+# on top is redundant and creates a label-toggle race with Mergify's own
+# `Label conflicting pull requests` rule (which uses `toggle` keyed on the
+# git-level `conflict` attribute, false for these PRs because the markers
+# are committed content, not unmerged tree state).
+BACKPORT_CONFLICT_LABEL = "backport-conflict"
 DEFAULT_MAX_RETRIES = 10
 DEFAULT_RETRY_DELAY = 5  # seconds
 DEFAULT_PER_PAGE = 100
@@ -273,7 +283,17 @@ def process_pr(api: GitHubAPI, pr: Dict[str, Any], conflict_label: str, max_retr
     mergeable_state = pr_details.get("mergeable_state", "")
     current_labels = [label["name"] for label in pr_details.get("labels", [])]
     has_conflict_label = conflict_label in current_labels
-    
+
+    if BACKPORT_CONFLICT_LABEL in current_labels:
+        log_info(f"  Skipping: {BACKPORT_CONFLICT_LABEL} label is set (Mergify owns this state)")
+        if has_conflict_label:
+            try:
+                api.remove_label(pr_number, conflict_label)
+                log_info(f"  ✅ Removed redundant {conflict_label} label from PR #{pr_number}")
+            except requests.exceptions.HTTPError as e:
+                log_warning(f"  Could not remove label: {e}")
+        return
+
     # Check for conflict markers in the diff (for Mergify backport PRs)
     diff_content = get_pr_diff(api.owner, api.repo, pr_number)
     has_markers = has_conflict_markers(diff_content) if diff_content else False


### PR DESCRIPTION
## Summary

Fixes an hourly label oscillation on Mergify-authored backport PRs whose cherry-pick committed conflict markers — `scripts/check-pr-conflicts.py` was adding `conflicts`, and the central `vyos/mergify` rule's `toggle` was stripping it ~30s later, repeating every cron tick.

Observed on [VyOS-Networks/vyos-1x#2190](https://github.com/VyOS-Networks/vyos-1x/pull/2190):

```
labeled   conflicts    by github-actions[bot]
unlabeled conflicts    by mergify[bot]              (~30s later)
labeled   conflicts    by github-actions[bot]       (next cron, ~60min later)
unlabeled conflicts    by mergify[bot]
…
```

## Root cause

Two label managers overload the `conflicts` label with different definitions:

| Surface | Definition of "conflict" | Verdict on PR #2190 |
|---|---|---|
| `scripts/check-pr-conflicts.py` (this repo) | `mergeable_state == "dirty"` **OR** diff contains `+<<<<<<<` / `+=======` / `+>>>>>>>` | yes — markers committed by Mergify backport |
| `vyos/mergify:.mergify.yml` `Label conflicting pull requests` rule | Mergify's built-in `conflict` attribute (= `mergeable_state == "dirty"`) | no — `MERGEABLE`, markers are committed content |

For these PRs the `backport-conflict` label (applied by Mergify's `backport.label_conflicts`) is already the canonical signal and already blocks merge via `merge_protections` in the central config, so the `conflicts` label is redundant in that state. The namespace collision with Mergify's `toggle` is what produces the oscillation.

## Change

`scripts/check-pr-conflicts.py`: early-return in `process_pr()` when the PR carries `backport-conflict`. Opportunistically remove any stale `conflicts` label so the next cron tick converges the state.

Diff-marker detection is preserved for non-Mergify PR shapes that may accumulate marker text outside the backport flow.

## Out of scope

- Renaming labels or changing the central `vyos/mergify` toggle rule
- Removing the diff-marker detection
- Defense-in-depth (required CI status, branch-protection ruleset on `backport-conflict`) — tracked under T8850 Cat 1

## Test plan

- [x] Python syntax check (`python3 -c "import ast; ast.parse(open(...).read())"`)
- [x] Phase 0 local CodeRabbit clean (0 findings)
- [ ] Mark ready-for-review once merged via Mergify queue
- [ ] After merge to `current`, observe next hourly cron on [VyOS-Networks/vyos-1x#2190](https://github.com/VyOS-Networks/vyos-1x/pull/2190) — should log "Skipping: backport-conflict label is set" and not re-add `conflicts`

## Phorge

T8934 (https://vyos.dev/T8934)

🤖 Generated by [robots](https://vyos.io)