### PR TITLE
chore: T8937: fix check-typos failure on pure-deletion PRs

### DIFF
--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -62,7 +62,7 @@ jobs:
       # Parse and format typos output to comment
       - name: Process typos output
         id: format_comments
-        if: always()
+        if: steps.typos.outcome != 'skipped'
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           REPO_URL: https://github.com/${{ github.repository }}
@@ -74,7 +74,7 @@ jobs:
 
       # Post comment with inline details (auto-updates on head changes)
       - name: Add PR comment with typo details
-        if: always()
+        if: steps.typos.outcome != 'skipped'
         uses: mshick/add-pr-comment@v3
         with:
           message: ${{ steps.format_comments.outputs.message }}


### PR DESCRIPTION
## Bug

When a PR touches only file deletions (e.g. the T8937 caller-workflow retirement sweep), \`dorny/paths-filter@v4\`'s \`added|modified: '**'\` filter returns false. The \`Run typos\` step is then skipped — but \`Process typos output\` (with \`if: always()\`) still runs, fails on the missing \`typos-output.json\`, and produces a red ❌ on the PR.

## Fix

Gate both \`Process typos output\` and \`Add PR comment with typo details\` on \`steps.typos.outcome != 'skipped'\`. Both steps now run when typos succeeded OR failed (the JSON exists), and are skipped when typos itself was skipped.

## Why

Unblocks T8937 Tier 1.2+ sweep PRs from needing admin-merge to bypass this false-positive failure. Tier 1.1 ([vyos/vyos-1x#5234](https://github.com/vyos/vyos-1x/pull/5234)) was admin-merged earlier as the canary; this fix lets Tier 1.2/1.3 and all of Tier 2/3 merge cleanly.

## Verification

The fix is observable on the very next pure-deletion PR opened against any repo that calls this reusable — \`check-typos\` job will be marked SKIPPED (green), not FAILED (red). No functional change on PRs that touch source files (typos still runs + reports as before).

Advances: T8937

🤖 Generated by [robots](https://vyos.io)