### PR TITLE
chore: T8937: add Bullfrog egress-audit step to check-typos

### DIFF
--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -25,6 +25,12 @@ jobs:
           repository: vyos/.github
           path: .github-repo
 
+      - name: Bullfrog Secure Runner
+        continue-on-error: true
+        uses: bullfrogsec/bullfrog@v0.8.4
+        with:
+          egress-policy: audit
+
       # Get changed files (excluding deleted)
       - name: Get changed files
         id: file-filter


### PR DESCRIPTION
Follow-up to [vyos/.github#128](https://github.com/vyos/.github/pull/128) — addresses CodeRabbit post-merge "Outside diff comments" finding that the typos job was missing the non-fatal Bullfrog egress-audit step present in 7 of 12 sibling reusable workflows.

Diff: 6-line addition. Step body matches the canonical placement pattern from `check-stale.yml` / `add-rebase-label.yml`. `continue-on-error: true` keeps it non-fatal (audit-only).

Advances: T8937

🤖 Generated by [robots](https://vyos.io)