### PR TITLE
docs: T8595: fix AGENTS.md self-reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,4 +51,4 @@ This repo is the canonical workflow library for both orgs. Consumers reference w
 - Any change merged to `current` ships to every consumer immediately. Test from a feature branch first via `uses:...@<branch>`.
 - Onboarding a repo to the mirror pipeline: see `PRMirrorOnboarding.md`.
 - Architecture & cross-org drift inventory: Confluence 792723546. GHA security hardening spec: 795344927. GHE baseline audit: 795967489.
-- This file (`CLAUDE.md`) is the authoritative working document for AI agents and contributors; keep it updated when conventions or layout change.
+- This file (`AGENTS.md`) is the authoritative working document for AI agents and contributors; keep it updated when conventions or layout change.


### PR DESCRIPTION
## What

`AGENTS.md` line 54 referred to itself as `CLAUDE.md`:

> - This file (\`CLAUDE.md\`) is the authoritative working document for AI agents and contributors…

Corrected the filename to `AGENTS.md`.

## Why

Residual from the CLAUDE.md → AGENTS.md migration (T8595). The self-reference named the wrong file, which is misleading for any contributor or agent reading the document's own provenance note.

## Scope

Single-line documentation fix. Surfaced by CodeRabbit during the rollout-1c compat-branch work but out of scope for that rename rollout, so split out here. Targets `current` (the default branch has not yet been renamed to `production` by rollout 1c).

Ref: T8595

🤖 Generated by [robots](https://vyos.io)