### PR TITLE
T8943: fix(mirror-rollout-2): reduce central permissions: {} for canonical stub

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -1,4 +1,7 @@
 
+# This workflow uses App tokens only. permissions: {} guarantees GITHUB_TOKEN
+# has no scope. Any new uses: or gh/curl step MUST pass an App token explicitly.
+# See spec: 2026-05-30-canonical-stub-permissions-fix-design.md
 name: PR Mirror and Repo Sync
 on:
   workflow_call:
@@ -21,10 +24,7 @@ env:
   MIRROR_SKIPPED_LABEL: 'mirror-skipped'
   CONSUMERS_REPO: 'VyOS-Networks/.github'
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 concurrency:
   group: trigger-pr-mirror-repo-sync-${{ github.event.inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
Follows up on PR [#132](https://github.com/vyos/.github/pull/132). Required before Rollout 2 Task 6 (per-consumer wrapper migration) can resume.

## Why

The canonical wrapper stub (spec §4.2.3) grants the caller only `permissions: contents: read`. Central declared top-level `{contents: write, pull-requests: write, issues: write}`. Per [GitHub docs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions), caller's grant < called workflow's declared permissions → `startup_failure`.

Empirically verified: [vyos/ipaddrcheck#33](https://github.com/vyos/ipaddrcheck/pull/33) applied canonical stub, next `pull_request_target` run `26693473386` failed with `startup_failure` and no logs. Revert PR [vyos/ipaddrcheck#34](https://github.com/vyos/ipaddrcheck/pull/34) restored function.

## What

Drop central's top-level `permissions:` block from the three-perm form to `{}`. Add App-token-only header comment.

## Audit: no step uses GITHUB_TOKEN

| Step / action | How it gets a token | Default GITHUB_TOKEN used? |
|---|---|---|
| `Bullfrog Secure Runner` | no token needed | no |
| `vyos/.github/.github/actions/get-token@production` | mints from `secrets.APP_PRIVATE_KEY` + `vars.APP_CLIENT_ID` | no |
| Every `run:` `gh ...` step | `env: GH_TOKEN: ${{ steps.{source,target}-token.outputs.token }}` | no |
| `actions/github-script@v6` | explicit `github-token: ${{ steps.source-token.outputs.token }}` | no |
| `actions/checkout@v6` | explicit `token: ${{ steps.target-token.outputs.token }}` | no |
| `curl` in `check-consumer-inclusion` | `-H "Authorization: token $GH_TOKEN"` (App token) | no |

## Compatibility

- Post-1b wrappers (callers granting `contents: write` etc.) continue to work — caller > called is the allowed direction.
- Canonical-stub wrappers (callers granting `contents: read`) now work — caller == called for the empty set.

## Validation

- YAML parses cleanly.
- actionlint produces no new warnings (pre-existing schema-lag false-positive on `job.workflow_ref` and SC2086 nits remain — known non-blockers, present in PR #132).
- Phase 0 local CodeRabbit clean.
- Post-merge smoke + excluded-repo no-op test scheduled per implementation plan.

## Rollback

State-dependent. See spec rollback section. Phase 0 (this PR alone): straight revert is safe. Phase 1+ (after any wrapper migrates): revert wrappers first.

Spec: `2026-05-30-canonical-stub-permissions-fix-design.md`
Plan: `2026-05-30-canonical-stub-permissions-fix.md`

Advances: T8943

🤖 Generated by [robots](https://vyos.io)