### PR TITLE
T8943: feat(mirror-rollout-3): remove bp/* injection; link-only mirror PR body; backport-pending label

### DIFF
--- a/.github/workflows/lts-name-check-reusable.yml
+++ b/.github/workflows/lts-name-check-reusable.yml
@@ -37,15 +37,15 @@ jobs:
           # Idempotency: use a stable hidden HTML-comment sentinel. Survives
           # comment-template edits and is invisible to readers but greppable.
           SENTINEL='<!-- lts-name-check: posted -->'
-          existing=$(gh api "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
-            --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+          existing=$(gh api --paginate "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
+            --jq "[.[] | select((.user.login | endswith(\"[bot]\")) and (.body | contains(\"$SENTINEL\")))] | length")
           if [ "$existing" != "0" ]; then
             echo "advisory comment already present (sentinel found); skipping"
             exit 0
           fi
           # Post the advisory. Body wording is generic — no matched name, no "backport".
           comment_body=$(printf '%s\n\n%s\n' \
-            "This PR's title or description appears to reference a VyOS LTS release-train branch name. Please remove release-train references from the title and body before merge — release/backport handling is managed separately by the maintainers after merge. This is a non-blocking advisory; no action is required to merge." \
+            "This PR's title or description appears to reference a VyOS LTS release-train branch name. Please remove release-train branch names from the title and body before merge. This is a non-blocking advisory; no action is required to merge." \
             "$SENTINEL")
           gh api -X POST "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
             -f body="$comment_body"

--- a/.github/workflows/lts-name-check-reusable.yml
+++ b/.github/workflows/lts-name-check-reusable.yml
@@ -1,0 +1,52 @@
+name: LTS-name advisory check (reusable)
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      # get-token is a COMPOSITE ACTION (not a reusable workflow).
+      # Call it at STEP level inside the job with owner: vyos.
+      - id: token
+        uses: vyos/.github/.github/actions/get-token@production
+        with:
+          owner: vyos
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Scan PR title + body for LTS branch names
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Generic regex — case-insensitive word boundaries.
+          # NOTE: do NOT echo matched terms in the comment body.
+          combined=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY")
+          if ! echo "$combined" | grep -qiE '\b(sagitta|circinus|equuleus)\b'; then
+            echo "no LTS branch names found in PR title/body"
+            exit 0
+          fi
+          # Idempotency: use a stable hidden HTML-comment sentinel. Survives
+          # comment-template edits and is invisible to readers but greppable.
+          SENTINEL='<!-- lts-name-check: posted -->'
+          existing=$(gh api "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
+            --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+          if [ "$existing" != "0" ]; then
+            echo "advisory comment already present (sentinel found); skipping"
+            exit 0
+          fi
+          # Post the advisory. Body wording is generic — no matched name, no "backport".
+          comment_body=$(printf '%s\n\n%s\n' \
+            "This PR's title or description appears to reference a VyOS LTS release-train branch name. Please remove release-train references from the title and body before merge — release/backport handling is managed separately by the maintainers after merge. This is a non-blocking advisory; no action is required to merge." \
+            "$SENTINEL")
+          gh api -X POST "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
+            -f body="$comment_body"
+          echo "advisory comment posted on PR #${PR_NUM}"

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -523,12 +523,13 @@ jobs:
           fi
           echo "last_commit=${last_commit}" >> $GITHUB_ENV
           echo "merge_commit=${merge_commit}" >> $GITHUB_ENV
-          # Write full PR body to a tmp file for later usage
+          # Write link-only PR body to a tmp file (spec §4.2.6 — no source body in mirror chain).
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
             echo "**Note**: This pull request is mirrored from PR [$PR_NUMBER](https://github.com/${SOURCE_REPO}/pull/${PR_NUMBER}) using [workflow run](${run_url})."
             echo ""
-            printf '%s\n' "$pr_body"   # exact preservation
+            echo "Mirror PR body is link-only — no LTS metadata in the mirror chain."
+            echo "Backport intent lives on this mirror PR: Maintainers post a backport command post-merge."
           } > /tmp/pr_body.txt
           echo "Last commit retrieved ${last_commit}, Merge commit retrieved ${merge_commit}, PR labels retrieved ${pr_labels}"
 
@@ -585,33 +586,33 @@ jobs:
           pr_number=$(basename $pr_url)
           echo "mirror_pr_number=${pr_number}" >> $GITHUB_ENV
 
+      # ── Side effect #4: Apply backport-pending label to mirror PR (marker only) ──
       - name: Re-check kill-switch before side effect
         if: env.mirror_required == 'true'
         env:
           MIRROR_ENABLED: ${{ vars.MIRROR_ENABLED }}
         run: |
           if [ "$MIRROR_ENABLED" = "false" ]; then
-            echo "::error::kill-switch flipped to false mid-run; aborting before side effect (backport comment)"
+            echo "::error::kill-switch flipped to false mid-run; aborting before side effect (backport-pending label)"
             exit 1
           fi
 
-      - name: Add mirror PR backport
+      - name: Apply backport-pending label to mirror PR
         if: env.mirror_required == 'true'
         env:
           GH_TOKEN: ${{ steps.target-token.outputs.token }}
         run: |
-          IFS=',' read -r -a labels <<< "$pr_labels"
-          for label in "${labels[@]}"; do
-            if [[ $label == bp/* ]]; then
-              bp_branch=${label#bp/}
-              if [[ -n "$bp_branch" ]]; then
-                echo "Adding backport for branch ${bp_branch}"
-                gh pr comment --repo ${TARGET_REPO} --body "@Mergifyio backport ${bp_branch}" $mirror_pr_number
-              fi
-            fi
-          done
+          # Ensure the label exists on the target repo before applying it — mirrors the
+          # create_label_if_not_exists pattern used for other mirror labels in this workflow.
+          if [[ $(gh label list --repo "$TARGET_REPO" --json name --jq '[.[].name] | index("backport-pending") != null') != "true" ]]; then
+            gh label create "backport-pending" --repo "$TARGET_REPO" --color "fbca04" \
+              --description "Mirror PR awaiting an LTS backport decision (Rollout 3)"
+          fi
+          gh api -X POST \
+            "repos/${TARGET_REPO}/issues/${mirror_pr_number}/labels" \
+            -f "labels[]=backport-pending"
 
-      # ── Side effect #4: Auto-merge mirror PR ──
+      # ── Side effect #5: Auto-merge mirror PR ──
       - name: Re-check kill-switch before side effect
         if: env.mirror_required == 'true'
         env:

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -606,7 +606,7 @@ jobs:
           # create_label_if_not_exists pattern used for other mirror labels in this workflow.
           if [[ $(gh label list --repo "$TARGET_REPO" --json name --jq '[.[].name] | index("backport-pending") != null') != "true" ]]; then
             gh label create "backport-pending" --repo "$TARGET_REPO" --color "fbca04" \
-              --description "Mirror PR awaiting an LTS backport decision (Rollout 3)"
+              --description "Mirror PR awaiting an LTS backport decision"
           fi
           gh api -X POST \
             "repos/${TARGET_REPO}/issues/${mirror_pr_number}/labels" \


### PR DESCRIPTION
## Summary

Rollout 3 leak-fix Task 2: central mirror workflow changes.

- **Removes** the `Add mirror PR backport` step — the `bp/*` label → `@Mergifyio backport` comment injection on mirror PRs. Also removes its preceding kill-switch re-check.
- **Adds** `Apply backport-pending label to mirror PR` step (with its own kill-switch re-check): applies a `backport-pending` marker label to newly-created mirror PRs. Maintainers issue the backport command post-merge on the mirror PR directly.
- **Changes** mirror PR body to link-only construction: removes verbatim source-PR body inheritance; body now contains only the mirror-link/run-link note and a brief explanation.
- Kill-switch re-check count unchanged at **8** (removed backport-comment re-check, added backport-pending re-check).

R3 leak-fix Task 2.

🤖 Generated by [robots](https://vyos.io)