### PR TITLE
T8943: fix(lts-name-check): add bullfrog egress-audit + correct paginated idempotency check

### DIFF
--- a/.github/workflows/lts-name-check-reusable.yml
+++ b/.github/workflows/lts-name-check-reusable.yml
@@ -9,6 +9,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Bullfrog Secure Runner
+        continue-on-error: true
+        uses: bullfrogsec/bullfrog@v0.8.4
+        with:
+          egress-policy: audit
+
       # get-token is a COMPOSITE ACTION (not a reusable workflow).
       # Call it at STEP level inside the job with owner: vyos.
       - id: token
@@ -38,8 +44,8 @@ jobs:
           # comment-template edits and is invisible to readers but greppable.
           SENTINEL='<!-- lts-name-check: posted -->'
           existing=$(gh api --paginate "repos/${PR_REPO}/issues/${PR_NUM}/comments" \
-            --jq "[.[] | select((.user.login | endswith(\"[bot]\")) and (.body | contains(\"$SENTINEL\")))] | length")
-          if [ "$existing" != "0" ]; then
+            --jq ".[] | select((.user.login | endswith(\"[bot]\")) and (.body | contains(\"$SENTINEL\"))) | .id")
+          if [ -n "$existing" ]; then
             echo "advisory comment already present (sentinel found); skipping"
             exit 0
           fi


### PR DESCRIPTION
Addresses two CodeRabbit review findings on `.github/workflows/lts-name-check-reusable.yml`.

**Fix A — Bullfrog egress-audit step:** adds the standard `Bullfrog Secure Runner` step as the first step in the `check` job, matching the pattern used in other workflows in this repo (`egress-policy: audit`, `continue-on-error: true`).

**Fix B — paginated idempotency check:** the prior form used `--paginate` with `[...] | length`, which emits one integer per page. The `!= "0"` test then misfires when comments span multiple API pages (each page emits independently). The replacement emits `.id` per matching comment and tests with `[ -n "$existing" ]`, which is page-count agnostic and correctly detects any match regardless of pagination.

🤖 Generated by [robots](https://vyos.io)