### PR TITLE
T8943: fix(mirror): make temp-clone cleanup non-fatal in pr-mirror-repo-sync

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -343,7 +343,11 @@ jobs:
           done
           echo "unmirrored_prs=$out" >> "$GITHUB_OUTPUT"
           echo "pr_landing_shas=$landing" >> "$GITHUB_OUTPUT"
-          rm -rf "$work"
+          # Non-fatal cleanup (T8943): a spurious `rm: cannot remove .../.git/objects:
+          # Directory not empty` (filesystem/handle race) as the step's last command would
+          # fail the step under set -e. The outputs above are already written; runner is
+          # ephemeral — never let cleanup gate the result.
+          rm -rf "$work" 2>/dev/null || true
 
 
   process-unmirrored-PR:
@@ -434,7 +438,10 @@ jobs:
             echo "PR ${PR_NUMBER} still absent from target; proceeding"
             echo "mirror_required=true" >> "$GITHUB_ENV"
           fi
-          cd - >/dev/null; rm -rf "$rc"
+          # Non-fatal cleanup (T8943): a spurious temp-dir rm failure under set -e would fail
+          # the step AFTER the reachability decision above, stranding the PR as mirror-failed.
+          # The decision is already recorded in $GITHUB_ENV; runner is ephemeral.
+          cd - >/dev/null; rm -rf "$rc" 2>/dev/null || true
 
       # ── Side effect #1: Apply mirror-initiated label on source PR ──
       - name: Re-check kill-switch before side effect


### PR DESCRIPTION
## What

The central PR-mirror reusable workflow intermittently strands healthy mirror runs as `mirror-failed` because of a spurious temp-directory cleanup failure.

Two steps — **Get unmirrored PRs (reachability — every run)** and the per-PR **reachability re-check** — each clone a temp repo into a `mktemp -d` dir and `rm -rf` it as the step's **last** command, under `set -euo pipefail`. The `rm` intermittently fails with:

```
rm: cannot remove '.../.git/objects': Directory not empty
```

(a filesystem/handle race). Because it is the last command under `set -e`, the whole step exits non-zero and fails — even though the reachability decision and the `GITHUB_OUTPUT` / `GITHUB_ENV` writes already completed successfully. The source PR is then labelled `mirror-failed` and no mirror PR is opened. Re-running the job (`gh run rerun <id> --failed`) clears it, confirming the reachability logic is correct and only the cleanup is at fault.

Observed on [vyos/ipaddrcheck#37](https://github.com/vyos/ipaddrcheck/pull/37), [run 26784780998](https://github.com/vyos/ipaddrcheck/actions/runs/26784780998), 2026-06-01.

## Fix

Guard both cleanups so a spurious cleanup error cannot gate the result:

```diff
-          rm -rf "$work"
+          rm -rf "$work" 2>/dev/null || true
```
```diff
-          cd - >/dev/null; rm -rf "$rc"
+          cd - >/dev/null; rm -rf "$rc" 2>/dev/null || true
```

Strictly additive — happy-path behaviour is byte-identical; only the failure case changes.

## Verification

- **actionlint**: findings identical to the production baseline (48 = 48, zero new, zero removed) — deterministic no-regression proof appropriate for a purely additive change.
- **Phase 0 local CodeRabbit** (`--base origin/production`): 0 findings.
- The underlying bug is an unforceable filesystem race; a green run proves *no-regression*, not that the race was reproduced.

## Scope

Audited the whole file for the same fragility. Exactly these two `rm -rf` of `mktemp` clone dirs qualify. `git remote rm tmp_source` (a remote op, not a dir-handle race) and `checkout_folder` under `/tmp/mirror/<pr>` (never `rm`'d) are intentionally out of scope.

🤖 Generated by [robots](https://vyos.io)