### PR TITLE
T8943: fix(mirror): non-fatal temp-clone cleanup in reconcile-rolling.sh

### DIFF
--- a/.github/scripts/reconcile-rolling.sh
+++ b/.github/scripts/reconcile-rolling.sh
@@ -44,7 +44,7 @@ if [ "$S" = "$T" ]; then
 fi
 
 # Full-depth clone of source; add target remote; fetch both (lease baseline + ancestry)
-work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+work="$(mktemp -d)"; trap 'rm -rf "$work" 2>/dev/null || true' EXIT
 git clone --quiet "https://x-access-token:$GH_TOKEN_SOURCE@github.com/$SRC.git" "$work/src"
 cd "$work/src"
 git remote add target "https://x-access-token:$GH_TOKEN_TARGET@github.com/$TGT.git"


### PR DESCRIPTION
Companion to #141. The EXIT-trap `rm -rf "$work"` in reconcile-rolling.sh races on large clones (vyos-1x) → spurious mirror-failed under set -e. One-line non-fatal fix (`2>/dev/null || true`), same pattern as #141's workflow-YAML fix. Diff <10 lines.

🤖 Generated by [robots](https://vyos.io)