### PR TITLE
chore: T8937: make PRs stale at 30 days as the message states

### DIFF
--- a/.github/workflows/check-stale.yml
+++ b/.github/workflows/check-stale.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
+        days-before-pr-stale: 30
         days-before-close: -1
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. The issue will be reviewed by a maintainer and may be closed'
         stale-issue-label: 'state: stale'


### PR DESCRIPTION
Fixes the message/config mismatch in the `check-stale.yml` reusable: `days-before-stale: 90` applied to both issues and PRs while `stale-pr-message` claimed 30 days. Operator-confirmed intent is 30-day PR staleness → adds `days-before-pr-stale: 30` (PRs only; issues keep 90). Behavior change for all consumer repos: PRs now get `state: stale` at 30 days instead of 90. `days-before-close: -1` unchanged — nothing auto-closes.

Pre-existing mismatch catalogued as a deferred follow-up in the T8937 retirement spec §8 ([T8937](https://vyos.dev/T8937), resolved).

Advances: T8937

🤖 Generated by [robots](https://vyos.io)