### PR TITLE
fix: T9001: fix check-unused-imports github-script for v9 Octokit API

### DIFF
--- a/.github/workflows/check-unused-imports.yml
+++ b/.github/workflows/check-unused-imports.yml
@@ -36,8 +36,8 @@ jobs:
               per_page: 100,
             });
             const changedFiles = files
-              .map(file => file.filename)
-              .filter(file => file.startsWith(checkFilePath));
+              .filter(file => file.status !== 'removed' && file.filename.startsWith(checkFilePath))
+              .map(file => file.filename);
             console.log("Changed files:", changedFiles);
             core.exportVariable('CHANGED_PY_FILES', changedFiles.join(' '));
 

--- a/.github/workflows/check-unused-imports.yml
+++ b/.github/workflows/check-unused-imports.yml
@@ -22,26 +22,24 @@ jobs:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
 
       - name: Get changed files
-        id: changed-files
         uses: actions/github-script@v9
+        env:
+          CHECK_FILE_PATH: ${{ inputs.check_file_path }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const { data: files } = await github.pulls.listFiles({
+            const checkFilePath = process.env.CHECK_FILE_PATH;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
+              per_page: 100,
             });
-            const checkFilePath = '${{ inputs.check_file_path }}';
-            const changedFiles = files.map(file => file.filename).filter(file => file.startsWith(checkFilePath));
+            const changedFiles = files
+              .map(file => file.filename)
+              .filter(file => file.startsWith(checkFilePath));
             console.log("Changed files:", changedFiles);
-            return { result: changedFiles.join(',') };
-
-      - name: Get changed py files
-        run: |
-          echo "Changed files: ${{ steps.changed-files.outputs.result }}"
-          py_files=$(echo ${{ steps.changed-files.outputs.result }} | sed 's/{result://; s/}//' | tr ',' ' ')
-          echo "CHANGED_PY_FILES=$py_files" >> $GITHUB_ENV
+            core.exportVariable('CHANGED_PY_FILES', changedFiles.join(' '));
 
       - name: Set up Python
         if: ${{ env.CHANGED_PY_FILES != '' }}


### PR DESCRIPTION
## Problem

The reusable workflow `.github/workflows/check-unused-imports.yml` fails at runtime on every consumer `pull_request` event. The `actions/github-script` "Get changed files" step throws:

> TypeError: Cannot read properties of undefined (reading 'listFiles')

Confirmed on `gh-action-test-vyos-build`: the check failed on 7 consecutive PRs (2026-05-13 → 2026-06-18); last success was 2026-05-07. It fails identically whether the caller pins `@current` or `@production` (the reusable is byte-identical on both branches), so it is a pre-existing, fleet-affecting bug, not environment-specific.

## Root cause

T8463 (commit 8071a41, 2026-05-07 — exactly the "last success" date) bumped `actions/github-script@v4` → `@v9` without updating the inline script. In github-script v5+ the Octokit REST methods moved under `github.rest.*`; the top-level `github.pulls` is now `undefined`, so `github.pulls.listFiles(...)` throws the TypeError.

A grep of every workflow on `production` confirms this is the only reusable whose github-script body used the old top-level Octokit namespace — **scope is one file**.

## Fix

- `github.pulls.listFiles` → `github.paginate(github.rest.pulls.listFiles, …)` — correct v9 namespace, with pagination so PRs touching >100 files don't silently drop migration scripts past the first page.
- Pass `check_file_path` via step `env:` → `process.env.CHECK_FILE_PATH` instead of interpolating `${{ inputs.check_file_path }}` into the script body.
- Replace the fragile `sed`-on-JSON output parsing (which mis-handled the ≥2-matched-file case via shell brace expansion) with `core.exportVariable('CHANGED_PY_FILES', …)`, removing the now-redundant bash parse step.
- Exclude deleted files (`status: 'removed'`) from the selection — their paths are absent from the merge checkout, so pylint would otherwise fail with `FileNotFoundError` on a PR that deletes a migration script (adversarial-review finding).

## Verification

The core fix was runtime-verified green on a throwaway consumer PR in `gh-action-test-vyos-build` (caller repointed at this branch + a clean migration script under `src/migration-scripts/`): the **Get changed files** step succeeded (no `TypeError`), `CHANGED_PY_FILES` exported and propagated, and the full **Set up Python → Install deps → pylint** path ran green (`10.00/10`) — exercising the non-empty path, not just the skip path. The later removed-files filter only narrows selection for deletions, leaving the verified added/modified path unchanged.

Phase-0 CodeRabbit clean; adversarial review (Codex + Gemini) run — 1 fix applied, 2 grounded pushbacks (see PR comment).

Tracking: T9001.

🤖 Generated by [robots](https://vyos.io)
