### PR TITLE
ci: T8490: typos config — exclude changelogs/generated + allowlist protobuf/j2lint identifiers

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -28,6 +28,16 @@ extend-exclude = [
     "smoketest/**",
     "mibs/**",
     "scripts/package-build/linux-kernel/config/**",
+    # Changelogs / release-note history: append-only records of past entries.
+    # Fixing typos there would rewrite historical release text. Skip them.
+    "ChangeLog",
+    "CHANGELOG*",
+    "debian/changelog",
+    # Generated protobuf type modules (ocaml-protoc output, e.g. vyconf_pbt.ml).
+    # Their content — incl. any baked-in identifier spelling — derives from the
+    # .proto source, not hand-editable here.
+    "*_pbt.ml",
+    "*_pbt.mli",
 ]
 
 [default.extend-words]
@@ -37,6 +47,22 @@ extend-exclude = [
 # templates, and interface-definition XML files.
 nd = "nd"
 ND = "ND"
+
+# vyconf protobuf enum `Uncommited_changes` (config-format errnum 9, wire-level):
+# defined in vyconf's data/vyconf.proto and referenced across the daemon API and
+# vyos-1x status handling. The spelling is an established identifier — renaming it
+# is a breaking change — so it is allowlisted rather than "corrected".
+Uncommited = "Uncommited"
+UNCOMMITED = "UNCOMMITED"
+
+# j2lint inline-directive rule name as written in FRR templates, e.g.
+# `{# j2lint: disable=jinja-statements-delimeter #}`. This matches j2lint's OWN
+# rule id, which upstream itself spells "delimeter" — aristanetworks/j2lint
+# JinjaStatementDelimeterRule defines `short_description = 'jinja-statements-delimeter'`.
+# It is the linter's identifier (used in a CI `make j2lint` directive), not VyOS
+# prose — rewriting it would point the directive at a non-existent rule. Allowlisted,
+# not "corrected" (do not "fix" to delimiter — that breaks the disable directive).
+delimeter = "delimeter"
 
 # WiFi 802.11ax / hostapd: FILS = Fast Initial Link Setup (IEEE 802.11ai).
 # A WPA3 authentication mechanism. Appears in wpa_supplicant.conf.j2 and


### PR DESCRIPTION
## What
Extends the central `_typos.toml` so the ruleset-required **Typos** check (T8490 Phase 2) can reach a clean baseline on the 4 pilot repos before the `evaluate → active` flip.

- **extend-exclude:** `ChangeLog` / `CHANGELOG*` / `debian/changelog` (append-only release history — fixing typos there would rewrite past entries) and `*_pbt.ml` / `*_pbt.mli` (ocaml-protoc generated protobuf type modules).
- **extend-words allowlist:** `Uncommited` / `UNCOMMITED` (vyconf protobuf enum `Uncommited_changes` — a wire-level identifier; renaming is breaking) and `delimeter` (j2lint's own rule id, used in FRR-template `make j2lint` disable directives).

## Why
Phase-2 Task 2.4 soak: the full-tree typos scan surfaces ~63 non-prose hits across the 4 pilot repos (notably vyatta-cfg-system 67→9 once changelogs are excluded). These are historical / generated / identifier tokens, not prose typos. Collapsing them here leaves only genuine prose typos, fixed in per-repo follow-up PRs.

## Verified baseline impact (typos v1.47.2, CI-style `typos . --config _typos.toml`)
| repo | before | after |
|---|---|---|
| vyos-1x | 75 | 59 |
| vyatta-cfg-system | 67 | 9 |
| vyconf | 14 | 7 |
| vyos-build | 1 | 1 |

Remaining hits are real prose typos → per-repo fix PRs, then the ruleset flips to `active`.

## Note for reviewers (incl. CodeRabbit)
The `delimeter` allowlist is intentional and correct: **j2lint upstream itself spells the rule `jinja-statements-delimeter`** — `aristanetworks/j2lint@341b5d5db86`, `JinjaStatementDelimeterRule` defines `short_description = 'jinja-statements-delimeter'`. "Correcting" it to `delimiter` would point the CI `make j2lint` disable directive at a non-existent rule.

Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555). Part of the typos-ruleset pilot (Phase 2, Task 2.4).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ