### PR TITLE
ci: T8490: allowlist mke2fs + Maya-calendar Mak (typos false positives)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -165,3 +165,22 @@ hda = "hda"
 # "grat." = gratuitous (as in "gratuitous ARP" / GARP). Conventional networking
 # abbreviation used in changelogs (e.g. "Extra grat. arps are not needed for vmac").
 grat = "grat"
+
+# "mke" — substring of the real command name `mke2fs` (make ext2/3/4 filesystem),
+# e.g. in a udev-rules comment "calling mke2fs or mkswap on it". Not a typo of "make".
+mke = "mke"
+
+# "Mak" — a month name in the Maya Haab' calendar (op-mode `maya_date`), alongside
+# Yax / Sak' / Keh / K'ank'in. A real proper noun, not a typo of "Make"/"Mask".
+Mak = "Mak"
+
+# "Dentifier" — the token typos extracts from "IDentifier" as written in the exact
+# RFC 4122 phrase "Universally Unique IDentifier (UUID)" (a hostapd-template comment).
+# The capitalised "ID" is the RFC's own styling, not a VyOS typo of "Identifier".
+Dentifier = "Dentifier"
+
+# "Forwrd" — the literal column header in upstream VPP's `vppctl show bridge-domain
+# <id> detail` output ("BD-ID … Learning U-Forwrd UU-Flood …"). op-mode/vpp.py mirrors
+# that exact header and the VPP smoketest asserts it verbatim, so it must NOT be
+# "corrected" to "Forward" — it is VPP's own output spelling, not a VyOS typo.
+Forwrd = "Forwrd"


### PR DESCRIPTION
## What
`_typos.toml` `extend-words` allowlist entries — genuine external tokens, NOT VyOS typos:
- `mke` — substring of the real command `mke2fs` (udev-rules comment), not "make".
- `Mak` — a Maya Haab' calendar month in op-mode `maya_date`, not "Make"/"Mask".
- `Dentifier` — from "Universally Unique IDentifier (UUID)", the exact RFC 4122 phrasing in a hostapd-template comment, not "Identifier".
- `Forwrd` — the literal column header in upstream VPP's `vppctl show bridge-domain <id> detail` output ("… Learning U-Forwrd UU-Flood …"), mirrored by `op_mode/vpp.py` and asserted verbatim by the VPP smoketest.

## Why
Lets `vyos-1x` reach a clean typos baseline for the T8490 ruleset pilot active flip. The hostapd wifi/radio jargon (FILS, OCE, aci, SME, Pn, BA, …) was already allowlisted centrally; these four close the remaining false positives surfaced during the vyos-1x pass (incl. one flagged by reviewers on [vyos/vyos-1x#5298](https://github.com/vyos/vyos-1x/pull/5298)).

Phase-0 CodeRabbit: no findings. Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ