### PR TITLE
ci: T9082: modernize CodeQL reusable — codeql-action v4 + build-mode input

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-# This workflow helps to analyze repository code for vulnerabilities, bugs, and other errors using CodeQL. 
+# This workflow helps to analyze repository code for vulnerabilities, bugs, and other errors using CodeQL.
 # For that CodeQL Action is used: https://github.com/github/codeql-action
 # Learn more about CodeQL at https://codeql.github.com/
 
@@ -8,12 +8,16 @@ on:
   workflow_call:
     inputs:
       languages:
-        description: "Optional input to set languages for CodeQL check. Supported values are: 'cpp', 'csharp', 'go', 'java', 'javascript', 'typescript', 'python', 'ruby'. To set multiple languages, use the same syntax as you can see in the default value."
+        description: "Optional input to set languages for CodeQL check. Supported values include: 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' (plus their documented aliases, e.g. 'cpp', 'c', 'javascript'). To set multiple languages, use the same syntax as you can see in the default value."
         required: false
         type: string
         default: "['python']"
       codeql-cfg-path:
         description: "Optional input to set path to a CodeQL config file"
+        required: false
+        type: string
+      build-mode:
+        description: "Optional input to set the CodeQL build mode: 'none', 'autobuild', or 'manual'. When unset, the legacy behavior applies (explicit Autobuild step, or build-command when provided). 'none' and 'autobuild' are handled by codeql-action itself and reject build-command; 'manual' requires build-command."
         required: false
         type: string
       build-command:
@@ -36,6 +40,29 @@ jobs:
         language: ${{fromJson(inputs.languages)}}
 
     steps:
+    - name: Validate build inputs
+      env:
+        BUILD_MODE: ${{inputs.build-mode}}
+        BUILD_COMMAND: ${{inputs.build-command}}
+      run: |
+        case "$BUILD_MODE" in
+          ''|none|autobuild|manual) ;;
+          *)
+            echo "::error::Invalid build-mode '$BUILD_MODE' (allowed: none, autobuild, manual, or unset)"
+            exit 1
+            ;;
+        esac
+        if [ "$BUILD_MODE" = "none" ] || [ "$BUILD_MODE" = "autobuild" ]; then
+          if [ -n "$BUILD_COMMAND" ]; then
+            echo "::error::build-command cannot be combined with build-mode '$BUILD_MODE'"
+            exit 1
+          fi
+        fi
+        if [ "$BUILD_MODE" = "manual" ] && [ -z "$BUILD_COMMAND" ]; then
+          echo "::error::build-mode 'manual' requires build-command"
+          exit 1
+        fi
+
     - name: Checkout
       uses: actions/checkout@v6
 
@@ -53,21 +80,24 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{matrix.language}}
         config-file: ${{inputs.codeql-cfg-path}}
+        build-mode: ${{inputs.build-mode}}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, configure a build command manually using build-command input. This command will be executed in the corresponding step.
+    # Runs only in legacy mode (no build-mode set): with build-mode 'none' or 'autobuild'
+    # codeql-action handles the build itself, and 'manual' uses the Manual build step below.
     - name: Autobuild
-      if: ${{!inputs.build-command}}
-      uses: github/codeql-action/autobuild@v3
+      if: ${{!inputs.build-command && !inputs.build-mode}}
+      uses: github/codeql-action/autobuild@v4
 
     - name: Manual build
-      if: ${{inputs.build-command}}
+      if: ${{inputs.build-command && (!inputs.build-mode || inputs.build-mode == 'manual')}}
       run: |
         ${{inputs.build-command}}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Track A of the vyos-org CodeQL rollout ([T9082](https://vyos.dev/T9082), [IS-610](https://vyos.atlassian.net/browse/IS-610)).

## What

- `github/codeql-action/{init,autobuild,analyze}` **v3 → v4** (v3 is deprecation-bound; v4 runs on Node 24).
- New optional **`build-mode`** input (`none` / `autobuild` / `manual`), passed through to `codeql-action/init`. When set, the explicit Autobuild step is skipped (`none`/`autobuild` are handled by codeql-action itself; `manual` requires and runs `build-command`).
- Leading **input-validation step** — fails fast on invalid `build-mode`/`build-command` combinations before any scanning cost.
- Languages doc string corrected to current canonical ids.

Unset `build-mode` keeps the same legacy behavior contract (explicit Autobuild step, or Manual build when `build-command` is provided) — all 4 existing callers (vyatta-cfg, vyatta-bash, vyos-build, vyos-1x) exercise only that path.

## Pre-merge verification (in flight)

Two canary caller PRs run pinned to this branch's SHA before merge: ipaddrcheck exercises the legacy autobuild row on v4, the validation failure path, and `build-mode: none`; rest.vyos exercises the legacy interpreted row. Post-merge, the 4 existing callers' latest runs are actively re-run (rerun re-resolves `@production`).

## Phase 0 (local CodeRabbit) dispositions

- *Major — `build-command` shell interpolation in the Manual build step:* pre-existing behavior, unchanged by this PR. `workflow_call` inputs come from a caller workflow committed to the calling repo — anyone able to set `build-command` can already run arbitrary steps in that repo's own workflows; no trust boundary is crossed. An allowlist would break the documented manual-build flexibility.
- *Minor — validate `build-mode: none` against language (Go/Kotlin/Swift unsupported):* skipped; `codeql-action/init` already fails fast with a clear upstream error for unsupported combinations, and duplicating its compatibility table here invites drift. Fleet callers use `none` only for c-cpp/python/javascript.

Advances: IS-610

🤖 Generated by [robots](https://vyos.io)

[IS-610]: https://vyos.atlassian.net/browse/IS-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ